### PR TITLE
feat: Phase 4 — Halogen UI components

### DIFF
--- a/client/dist/style.css
+++ b/client/dist/style.css
@@ -1,2 +1,28 @@
 * { box-sizing: border-box; margin: 0; padding: 0; }
-body { font-family: system-ui, sans-serif; padding: 1rem; }
+body { font-family: system-ui, sans-serif; padding: 1rem; max-width: 800px; margin: 0 auto; color: #333; }
+h1 { font-size: 1.5rem; }
+h2 { font-size: 1.2rem; margin: 1rem 0 0.5rem; }
+h3 { font-size: 1rem; margin: 0.8rem 0 0.4rem; }
+.header { display: flex; justify-content: space-between; align-items: center; padding: 0.5rem 0; border-bottom: 1px solid #ddd; margin-bottom: 1rem; }
+.user-id { font-family: monospace; font-size: 0.8rem; color: #666; }
+.error-bar { background: #fee; color: #c00; padding: 0.5rem; border-radius: 4px; margin-bottom: 1rem; }
+.error { color: #c00; margin-top: 0.5rem; }
+.aid { font-family: monospace; font-size: 0.9rem; word-break: break-all; }
+button { padding: 0.4rem 0.8rem; border: 1px solid #ccc; border-radius: 4px; background: #fff; cursor: pointer; margin: 0.2rem; }
+button:hover { background: #f0f0f0; }
+.btn-primary { background: #2563eb; color: #fff; border-color: #2563eb; }
+.btn-primary:hover { background: #1d4ed8; }
+input { padding: 0.4rem; border: 1px solid #ccc; border-radius: 4px; margin: 0.2rem; }
+.form { display: flex; gap: 0.5rem; align-items: center; flex-wrap: wrap; margin: 0.5rem 0; }
+.stats { display: flex; gap: 1rem; margin: 0.5rem 0; }
+.stat { text-align: center; }
+.stat-value { display: block; font-size: 1.5rem; font-weight: bold; }
+.stat-label { font-size: 0.8rem; color: #666; }
+.purchase-link { cursor: pointer; color: #2563eb; text-decoration: underline; }
+table { width: 100%; border-collapse: collapse; margin: 0.5rem 0; }
+th, td { text-align: left; padding: 0.3rem 0.5rem; border-bottom: 1px solid #eee; }
+th { font-weight: 600; border-bottom: 2px solid #ddd; }
+.group-id { font-family: monospace; font-size: 0.85rem; color: #666; }
+.group-setup { text-align: center; margin-top: 2rem; }
+.identity-screen { text-align: center; margin-top: 3rem; }
+.nav-buttons { margin: 0.5rem 0; }

--- a/client/src/Main.purs
+++ b/client/src/Main.purs
@@ -1,8 +1,13 @@
 module Main where
 
 import Prelude
+
 import Effect (Effect)
-import Effect.Console (log)
+import Halogen.Aff as HA
+import Halogen.VDom.Driver (runUI)
+import View.App (appComponent)
 
 main :: Effect Unit
-main = log "keri-coop client loading"
+main = HA.runHalogenAff do
+  body <- HA.awaitBody
+  runUI appComponent unit body

--- a/client/src/View/App.purs
+++ b/client/src/View/App.purs
@@ -1,0 +1,192 @@
+module View.App
+  ( appComponent
+  ) where
+
+import Prelude
+
+import Data.Const (Const)
+import Data.Maybe (Maybe(..))
+import Data.String as String
+import Domain.Event (DomainEvent(..))
+import Domain.State (GroupState)
+import Domain.State as DS
+import Domain.Types (PurchaseName(..))
+import Effect.Aff.Class (class MonadAff)
+import Halogen as H
+import Halogen.HTML as HH
+import Halogen.HTML.Events as HE
+import Halogen.HTML.Properties as HP
+import Type.Proxy (Proxy(..))
+import View.Dashboard as Dashboard
+import View.Identity as Identity
+import View.Members as Members
+import View.Purchase as Purchase
+import View.Types (Identity, Screen(..))
+import View.Wallet as Wallet
+
+type State =
+  { screen :: Screen
+  , identity :: Maybe Identity
+  , groupId :: Maybe String
+  , groupState :: GroupState
+  , newGroupInput :: String
+  , newPurchaseInput :: String
+  , error :: Maybe String
+  }
+
+data Action
+  = HandleIdentity Identity
+  | HandleDashboard Dashboard.Output
+  | HandleMembers Members.Output
+  | HandleWallet Wallet.Output
+  | HandlePurchase Purchase.Output
+  | SetNewGroupInput String
+  | SetNewPurchaseInput String
+  | CreateGroup
+  | JoinGroup
+  | OpenNewPurchase
+  | SubmitEvent DomainEvent
+  | Navigate Screen
+
+type Slots =
+  ( identity :: H.Slot (Const Void) Identity.Output Unit
+  , dashboard :: H.Slot (Const Void) Dashboard.Output Unit
+  , members :: H.Slot (Const Void) Members.Output Unit
+  , wallet :: H.Slot (Const Void) Wallet.Output Unit
+  , purchase :: H.Slot (Const Void) Purchase.Output Unit
+  )
+
+appComponent :: forall q i o m. MonadAff m => H.Component q i o m
+appComponent = H.mkComponent
+  { initialState: const initialState
+  , render
+  , eval: H.mkEval H.defaultEval
+      { handleAction = handleAction }
+  }
+
+initialState :: State
+initialState =
+  { screen: IdentityScreen
+  , identity: Nothing
+  , groupId: Nothing
+  , groupState: DS.emptyState
+  , newGroupInput: ""
+  , newPurchaseInput: ""
+  , error: Nothing
+  }
+
+render :: forall m. MonadAff m => State -> H.ComponentHTML Action Slots m
+render st = HH.div [ HP.class_ (HH.ClassName "app") ]
+  [ header st
+  , case st.error of
+      Just err -> HH.div [ HP.class_ (HH.ClassName "error-bar") ] [ HH.text err ]
+      Nothing -> HH.text ""
+  , content st
+  ]
+
+header :: forall m. State -> H.ComponentHTML Action Slots m
+header st = HH.nav [ HP.class_ (HH.ClassName "header") ]
+  [ HH.h1_ [ HH.text "keri-coop" ]
+  , case st.identity of
+      Just ident -> HH.span [ HP.class_ (HH.ClassName "user-id") ]
+        [ HH.text (take8 ident.prefix) ]
+      Nothing -> HH.text ""
+  ]
+  where
+  take8 s = if String.length s > 8 then String.take 8 s <> "..." else s
+
+content :: forall m. MonadAff m => State -> H.ComponentHTML Action Slots m
+content st = case st.screen of
+  IdentityScreen ->
+    HH.slot (Proxy :: _ "identity") unit Identity.identityComponent unit HandleIdentity
+
+  DashboardScreen -> case st.groupId of
+    Nothing -> groupSetup st
+    Just _ ->
+      HH.div_
+        [ HH.slot (Proxy :: _ "dashboard") unit Dashboard.dashboardComponent
+            { groupState: st.groupState, groupId: st.groupId }
+            HandleDashboard
+        , HH.div [ HP.class_ (HH.ClassName "form") ]
+            [ HH.input
+                [ HP.placeholder "Purchase name"
+                , HP.value st.newPurchaseInput
+                , HE.onValueInput SetNewPurchaseInput
+                ]
+            , HH.button [ HE.onClick (const OpenNewPurchase) ] [ HH.text "Open Purchase" ]
+            ]
+        ]
+
+  MembersScreen ->
+    HH.slot (Proxy :: _ "members") unit Members.membersComponent
+      { groupState: st.groupState, myId: map _.memberId st.identity }
+      HandleMembers
+
+  WalletScreen ->
+    HH.slot (Proxy :: _ "wallet") unit Wallet.walletComponent
+      { groupState: st.groupState, myId: map _.memberId st.identity }
+      HandleWallet
+
+  PurchaseScreen pid ->
+    HH.slot (Proxy :: _ "purchase") unit Purchase.purchaseComponent
+      { groupState: st.groupState, purchaseId: pid, myId: map _.memberId st.identity }
+      HandlePurchase
+
+groupSetup :: forall m. State -> H.ComponentHTML Action Slots m
+groupSetup st = HH.div [ HP.class_ (HH.ClassName "group-setup") ]
+  [ HH.h2_ [ HH.text "Join or Create a Group" ]
+  , HH.div [ HP.class_ (HH.ClassName "form") ]
+      [ HH.input
+          [ HP.placeholder "Group ID"
+          , HP.value st.newGroupInput
+          , HE.onValueInput SetNewGroupInput
+          ]
+      , HH.button [ HE.onClick (const JoinGroup) ] [ HH.text "Join" ]
+      , HH.button [ HE.onClick (const CreateGroup) ] [ HH.text "Create New" ]
+      ]
+  ]
+
+handleAction :: forall o m. MonadAff m => Action -> H.HalogenM State Action Slots o m Unit
+handleAction = case _ of
+  HandleIdentity ident -> do
+    H.modify_ _ { identity = Just ident, screen = DashboardScreen }
+
+  HandleDashboard output -> case output of
+    Dashboard.NavigatePurchase pid -> H.modify_ _ { screen = PurchaseScreen pid }
+    Dashboard.NavigateMembers -> H.modify_ _ { screen = MembersScreen }
+    Dashboard.NavigateWallet -> H.modify_ _ { screen = WalletScreen }
+
+  HandleMembers output -> case output of
+    Members.SubmitDomainEvent ev -> handleAction (SubmitEvent ev)
+    Members.NavigateBack -> H.modify_ _ { screen = DashboardScreen }
+
+  HandleWallet output -> case output of
+    Wallet.SubmitDomainEvent ev -> handleAction (SubmitEvent ev)
+    Wallet.NavigateBack -> H.modify_ _ { screen = DashboardScreen }
+
+  HandlePurchase output -> case output of
+    Purchase.SubmitDomainEvent ev -> handleAction (SubmitEvent ev)
+    Purchase.NavigateBack -> H.modify_ _ { screen = DashboardScreen }
+
+  SetNewGroupInput s -> H.modify_ _ { newGroupInput = s }
+  SetNewPurchaseInput s -> H.modify_ _ { newPurchaseInput = s }
+
+  CreateGroup -> do
+    H.modify_ _ { groupId = Just "demo-group", groupState = DS.emptyState }
+
+  JoinGroup -> do
+    st <- H.get
+    when (st.newGroupInput /= "") do
+      H.modify_ _ { groupId = Just st.newGroupInput, newGroupInput = "" }
+
+  OpenNewPurchase -> do
+    st <- H.get
+    when (st.newPurchaseInput /= "") do
+      handleAction (SubmitEvent (OpenPurchase (PurchaseName st.newPurchaseInput)))
+      H.modify_ _ { newPurchaseInput = "" }
+
+  SubmitEvent _ev -> do
+    -- TODO: sign and send via Protocol.Message + Protocol.Client
+    pure unit
+
+  Navigate screen -> H.modify_ _ { screen = screen }

--- a/client/src/View/Dashboard.purs
+++ b/client/src/View/Dashboard.purs
@@ -1,0 +1,88 @@
+module View.Dashboard
+  ( dashboardComponent
+  , Output(..)
+  , Input
+  ) where
+
+import Prelude
+
+import Data.Array as Array
+import Data.Map as Map
+import Data.Maybe (Maybe(..))
+import Data.Tuple (Tuple(..))
+import Domain.State (GroupState, PurchasePhase(..), adminCount)
+import Domain.Types (PurchaseId(..))
+import Halogen as H
+import Halogen.HTML as HH
+import Halogen.HTML.Events as HE
+import Halogen.HTML.Properties as HP
+
+type Input =
+  { groupState :: GroupState
+  , groupId :: Maybe String
+  }
+
+data Action
+  = Receive Input
+  | ClickPurchase PurchaseId
+  | ClickMembers
+  | ClickWallet
+
+data Output
+  = NavigatePurchase PurchaseId
+  | NavigateMembers
+  | NavigateWallet
+
+dashboardComponent :: forall q m. H.Component q Input Output m
+dashboardComponent = H.mkComponent
+  { initialState: identity
+  , render
+  , eval: H.mkEval H.defaultEval
+      { receive = Just <<< Receive
+      , handleAction = handleAction
+      }
+  }
+
+render :: forall m. Input -> H.ComponentHTML Action () m
+render { groupState: gs, groupId } = HH.div [ HP.class_ (HH.ClassName "dashboard") ]
+  [ HH.h2_ [ HH.text "Dashboard" ]
+  , case groupId of
+      Just gid -> HH.p [ HP.class_ (HH.ClassName "group-id") ]
+        [ HH.text ("Group: " <> gid) ]
+      Nothing -> HH.text ""
+  , HH.div [ HP.class_ (HH.ClassName "stats") ]
+      [ stat "Members" (show (Map.size gs.members))
+      , stat "Admins" (show (adminCount gs))
+      , stat "Purchases" (show (Map.size gs.purchases))
+      ]
+  , HH.div [ HP.class_ (HH.ClassName "nav-buttons") ]
+      [ HH.button [ HE.onClick (const ClickMembers) ] [ HH.text "Members" ]
+      , HH.button [ HE.onClick (const ClickWallet) ] [ HH.text "Wallet" ]
+      ]
+  , HH.h3_ [ HH.text "Open Purchases" ]
+  , HH.ul_ (map renderPurchase openPurchases)
+  ]
+  where
+  openPurchases :: Array (Tuple PurchaseId _)
+  openPurchases = Array.filter (\(Tuple _ ps) -> ps.phase == Open)
+    (Map.toUnfoldable gs.purchases)
+
+  renderPurchase (Tuple (PurchaseId pid) ps) = HH.li_
+    [ HH.a
+        [ HE.onClick (const (ClickPurchase (PurchaseId pid)))
+        , HP.class_ (HH.ClassName "purchase-link")
+        ]
+        [ HH.text (show ps.name <> " (" <> show (Map.size ps.commitments) <> " commitments)") ]
+    ]
+
+  stat label value = HH.div [ HP.class_ (HH.ClassName "stat") ]
+    [ HH.span [ HP.class_ (HH.ClassName "stat-value") ] [ HH.text value ]
+    , HH.span [ HP.class_ (HH.ClassName "stat-label") ] [ HH.text label ]
+    ]
+
+handleAction :: forall m. Action -> H.HalogenM Input Action () Output m Unit
+handleAction = case _ of
+  Receive input -> H.put input
+  ClickPurchase pid -> H.raise (NavigatePurchase pid)
+  ClickMembers -> H.raise NavigateMembers
+  ClickWallet -> H.raise NavigateWallet

--- a/client/src/View/Identity.purs
+++ b/client/src/View/Identity.purs
@@ -1,0 +1,107 @@
+module View.Identity
+  ( identityComponent
+  , Output
+  ) where
+
+import Prelude
+
+import Data.Maybe (Maybe(..))
+import Domain.Types (AID(..), MemberId(..))
+import Effect.Aff.Class (class MonadAff)
+import Effect.Class (liftEffect)
+import FFI.Storage as Storage
+import FFI.TweetNaCl as NaCl
+import Halogen as H
+import Halogen.HTML as HH
+import Halogen.HTML.Events as HE
+import Halogen.HTML.Properties as HP
+import Keri.Cesr.DerivationCode (DerivationCode(..))
+import Keri.Cesr.Encode as Cesr
+import Keri.Cesr.Primitive (mkPrimitive)
+import Data.Either (Either(..))
+import View.Types (Identity)
+
+type State =
+  { identity :: Maybe Identity
+  , error :: Maybe String
+  }
+
+data Action
+  = Init
+  | Generate
+  | LoadExisting
+
+type Output = Identity
+
+identityComponent :: forall q m. MonadAff m => H.Component q Unit Output m
+identityComponent = H.mkComponent
+  { initialState: const { identity: Nothing, error: Nothing }
+  , render
+  , eval: H.mkEval H.defaultEval
+      { initialize = Just Init
+      , handleAction = handleAction
+      }
+  }
+
+render :: forall m. State -> H.ComponentHTML Action () m
+render st = HH.div [ HP.class_ (HH.ClassName "identity-screen") ]
+  case st.identity of
+    Just ident ->
+      [ HH.h2_ [ HH.text "Your Identity" ]
+      , HH.p [ HP.class_ (HH.ClassName "aid") ]
+          [ HH.text ident.prefix ]
+      , HH.p_ [ HH.text "Identity loaded. Ready to join a group." ]
+      ]
+    Nothing ->
+      [ HH.h2_ [ HH.text "Welcome to keri-coop" ]
+      , HH.p_ [ HH.text "Generate a new KERI identity to get started." ]
+      , HH.button
+          [ HE.onClick (const Generate)
+          , HP.class_ (HH.ClassName "btn-primary")
+          ]
+          [ HH.text "Generate Identity" ]
+      , case st.error of
+          Just err -> HH.p [ HP.class_ (HH.ClassName "error") ] [ HH.text err ]
+          Nothing -> HH.text ""
+      ]
+
+handleAction :: forall m. MonadAff m => Action -> H.HalogenM State Action () Output m Unit
+handleAction = case _ of
+  Init -> do
+    mPrefix <- liftEffect $ Storage.getItem "keri-coop-prefix"
+    case mPrefix of
+      Just _ -> handleAction LoadExisting
+      Nothing -> pure unit
+
+  LoadExisting -> do
+    mPrefix <- liftEffect $ Storage.getItem "keri-coop-prefix"
+    mSecret <- liftEffect $ Storage.getItem "keri-coop-secret"
+    case mPrefix, mSecret of
+      Just prefix, Just _ -> do
+        kp <- liftEffect NaCl.generateKeyPair
+        let
+          ident =
+            { keyPair: kp
+            , prefix
+            , memberId: MemberId (AID prefix)
+            }
+        H.modify_ _ { identity = Just ident }
+        H.raise ident
+      _, _ -> pure unit
+
+  Generate -> do
+    kp <- liftEffect NaCl.generateKeyPair
+    case mkPrimitive Ed25519PubKey kp.publicKey of
+      Left err -> H.modify_ _ { error = Just err }
+      Right prim -> do
+        let
+          prefix = Cesr.encode prim
+          ident =
+            { keyPair: kp
+            , prefix
+            , memberId: MemberId (AID prefix)
+            }
+        liftEffect do
+          Storage.setItem "keri-coop-prefix" prefix
+        H.modify_ _ { identity = Just ident, error = Nothing }
+        H.raise ident

--- a/client/src/View/Members.purs
+++ b/client/src/View/Members.purs
@@ -1,0 +1,114 @@
+module View.Members
+  ( membersComponent
+  , Output(..)
+  , Input
+  ) where
+
+import Prelude
+
+import Data.Map as Map
+import Data.Maybe (Maybe(..))
+import Data.Set as Set
+import Data.Tuple (Tuple(..))
+import Domain.Event as DE
+import Domain.State (GroupState)
+import Domain.Types (MemberId, MemberName(..))
+import Halogen as H
+import Halogen.HTML as HH
+import Halogen.HTML.Events as HE
+import Halogen.HTML.Properties as HP
+
+type Input =
+  { groupState :: GroupState
+  , myId :: Maybe MemberId
+  }
+
+type State =
+  { groupState :: GroupState
+  , myId :: Maybe MemberId
+  , newMemberName :: String
+  }
+
+data Action
+  = Receive Input
+  | SetNewMemberName String
+  | VoteRegister
+  | VoteElectReferente MemberId
+  | VoteElectCassiere MemberId
+  | GoBack
+
+data Output
+  = SubmitDomainEvent DE.DomainEvent
+  | NavigateBack
+
+membersComponent :: forall q m. H.Component q Input Output m
+membersComponent = H.mkComponent
+  { initialState: \i -> { groupState: i.groupState, myId: i.myId, newMemberName: "" }
+  , render
+  , eval: H.mkEval H.defaultEval
+      { receive = Just <<< Receive
+      , handleAction = handleAction
+      }
+  }
+
+render :: forall m. State -> H.ComponentHTML Action () m
+render st = HH.div [ HP.class_ (HH.ClassName "members") ]
+  [ HH.button [ HE.onClick (const GoBack) ] [ HH.text "Back" ]
+  , HH.h2_ [ HH.text "Members" ]
+  , HH.div [ HP.class_ (HH.ClassName "register-form") ]
+      [ HH.input
+          [ HP.placeholder "New member name"
+          , HP.value st.newMemberName
+          , HE.onValueInput SetNewMemberName
+          ]
+      , HH.button
+          [ HE.onClick (const VoteRegister) ]
+          [ HH.text "Vote Register" ]
+      ]
+  , HH.table_
+      [ HH.thead_
+          [ HH.tr_
+              [ HH.th_ [ HH.text "Name" ]
+              , HH.th_ [ HH.text "Roles" ]
+              , HH.th_ [ HH.text "Actions" ]
+              ]
+          ]
+      , HH.tbody_ (map renderMember members)
+      ]
+  ]
+  where
+  members :: Array (Tuple MemberId MemberName)
+  members = Map.toUnfoldable st.groupState.members
+
+  renderMember (Tuple mid (MemberName name)) = HH.tr_
+    [ HH.td_ [ HH.text name ]
+    , HH.td_ [ HH.text (roles mid) ]
+    , HH.td_
+        [ HH.button
+            [ HE.onClick (const (VoteElectReferente mid)) ]
+            [ HH.text "Referente" ]
+        , HH.button
+            [ HE.onClick (const (VoteElectCassiere mid)) ]
+            [ HH.text "Cassiere" ]
+        ]
+    ]
+
+  roles mid =
+    let
+      r = if Set.member mid st.groupState.referenti then "R" else ""
+      c = if Set.member mid st.groupState.cassieri then "C" else ""
+    in
+      r <> c
+
+handleAction :: forall m. Action -> H.HalogenM State Action () Output m Unit
+handleAction = case _ of
+  Receive i -> H.modify_ _ { groupState = i.groupState, myId = i.myId }
+  SetNewMemberName s -> H.modify_ _ { newMemberName = s }
+  VoteRegister -> do
+    st <- H.get
+    when (st.newMemberName /= "") do
+      H.raise (SubmitDomainEvent (DE.VoteRegisterMember (MemberName st.newMemberName)))
+      H.modify_ _ { newMemberName = "" }
+  VoteElectReferente mid -> H.raise (SubmitDomainEvent (DE.VoteElectReferente mid))
+  VoteElectCassiere mid -> H.raise (SubmitDomainEvent (DE.VoteElectCassiere mid))
+  GoBack -> H.raise NavigateBack

--- a/client/src/View/Purchase.purs
+++ b/client/src/View/Purchase.purs
@@ -1,0 +1,155 @@
+module View.Purchase
+  ( purchaseComponent
+  , Output(..)
+  , Input
+  ) where
+
+import Prelude
+
+import Data.Int as Int
+import Data.Map as Map
+import Data.Maybe (Maybe(..))
+import Data.Set as Set
+import Data.Tuple (Tuple(..))
+import Domain.Event (DomainEvent(..))
+import Domain.State (GroupState, PurchasePhase(..), CommitmentStatus(..), quorum)
+import Domain.Types (Cents(..), MemberId, MemberName(..), PurchaseId, PurchaseName(..))
+import Halogen as H
+import Halogen.HTML as HH
+import Halogen.HTML.Events as HE
+import Halogen.HTML.Properties as HP
+
+type Input =
+  { groupState :: GroupState
+  , purchaseId :: PurchaseId
+  , myId :: Maybe MemberId
+  }
+
+type State =
+  { groupState :: GroupState
+  , purchaseId :: PurchaseId
+  , myId :: Maybe MemberId
+  , commitAmount :: String
+  }
+
+data Action
+  = Receive Input
+  | SetCommitAmount String
+  | SubmitCommit
+  | Approve MemberId
+  | Reject MemberId
+  | VoteClose
+  | VoteFail
+  | Close
+  | Fail
+  | GoBack
+
+data Output
+  = SubmitDomainEvent DomainEvent
+  | NavigateBack
+
+purchaseComponent :: forall q m. H.Component q Input Output m
+purchaseComponent = H.mkComponent
+  { initialState: \i ->
+      { groupState: i.groupState
+      , purchaseId: i.purchaseId
+      , myId: i.myId
+      , commitAmount: ""
+      }
+  , render
+  , eval: H.mkEval H.defaultEval
+      { receive = Just <<< Receive
+      , handleAction = handleAction
+      }
+  }
+
+render :: forall m. State -> H.ComponentHTML Action () m
+render st = HH.div [ HP.class_ (HH.ClassName "purchase") ]
+  case Map.lookup st.purchaseId st.groupState.purchases of
+    Nothing -> [ HH.text "Purchase not found" ]
+    Just ps ->
+      [ HH.button [ HE.onClick (const GoBack) ] [ HH.text "Back" ]
+      , HH.h2_ [ HH.text (nameStr ps.name) ]
+      , HH.p_ [ HH.text ("Phase: " <> phaseStr ps.phase) ]
+      , HH.p_ [ HH.text ("Close votes: " <> show (Set.size ps.closeVotes) <> "/" <> show (quorum st.groupState)) ]
+      , HH.p_ [ HH.text ("Fail votes: " <> show (Set.size ps.failVotes) <> "/" <> show (quorum st.groupState)) ]
+      , HH.h3_ [ HH.text "Commitments" ]
+      , HH.table_
+          [ HH.thead_
+              [ HH.tr_
+                  [ HH.th_ [ HH.text "Member" ]
+                  , HH.th_ [ HH.text "Amount" ]
+                  , HH.th_ [ HH.text "Status" ]
+                  , HH.th_ [ HH.text "Actions" ]
+                  ]
+              ]
+          , HH.tbody_ (map renderCommitment (Map.toUnfoldable ps.commitments))
+          ]
+      , if ps.phase == Open then
+          HH.div [ HP.class_ (HH.ClassName "form") ]
+            [ HH.h3_ [ HH.text "Commit" ]
+            , HH.input [ HP.placeholder "Amount (cents)", HP.value st.commitAmount, HE.onValueInput SetCommitAmount ]
+            , HH.button [ HE.onClick (const SubmitCommit) ] [ HH.text "Commit" ]
+            , HH.h3_ [ HH.text "Admin actions" ]
+            , HH.button [ HE.onClick (const VoteClose) ] [ HH.text "Vote Close" ]
+            , HH.button [ HE.onClick (const VoteFail) ] [ HH.text "Vote Fail" ]
+            , HH.button [ HE.onClick (const Close) ] [ HH.text "Close" ]
+            , HH.button [ HE.onClick (const Fail) ] [ HH.text "Fail" ]
+            ]
+        else HH.text ""
+      ]
+  where
+  renderCommitment (Tuple mid { amount: Cents cents, status }) =
+    let
+      memberName = case Map.lookup mid st.groupState.members of
+        Just (MemberName n) -> n
+        Nothing -> show mid
+    in
+      HH.tr_
+        [ HH.td_ [ HH.text memberName ]
+        , HH.td_ [ HH.text (show cents) ]
+        , HH.td_ [ HH.text (statusStr status) ]
+        , HH.td_
+            [ HH.button [ HE.onClick (const (Approve mid)) ] [ HH.text "Approve" ]
+            , HH.button [ HE.onClick (const (Reject mid)) ] [ HH.text "Reject" ]
+            ]
+        ]
+
+  nameStr (PurchaseName n) = n
+  phaseStr Open = "Open"
+  phaseStr Closed = "Closed"
+  phaseStr Failed = "Failed"
+  statusStr Pending = "Pending"
+  statusStr Approved = "Approved"
+  statusStr Rejected = "Rejected"
+
+handleAction :: forall m. Action -> H.HalogenM State Action () Output m Unit
+handleAction = case _ of
+  Receive i -> H.modify_ _ { groupState = i.groupState, purchaseId = i.purchaseId, myId = i.myId }
+  SetCommitAmount s -> H.modify_ _ { commitAmount = s }
+  SubmitCommit -> do
+    st <- H.get
+    case st.myId, Int.fromString st.commitAmount of
+      Just mid, Just cents -> do
+        H.raise (SubmitDomainEvent (Commit mid (Cents cents) st.purchaseId))
+        H.modify_ _ { commitAmount = "" }
+      _, _ -> pure unit
+  Approve mid -> do
+    st <- H.get
+    H.raise (SubmitDomainEvent (ApproveCommitment mid st.purchaseId))
+  Reject mid -> do
+    st <- H.get
+    H.raise (SubmitDomainEvent (RejectCommitment mid st.purchaseId))
+  VoteClose -> do
+    st <- H.get
+    H.raise (SubmitDomainEvent (VoteClosePurchase st.purchaseId))
+  VoteFail -> do
+    st <- H.get
+    H.raise (SubmitDomainEvent (VoteFailPurchase st.purchaseId))
+  Close -> do
+    st <- H.get
+    H.raise (SubmitDomainEvent (ClosePurchase st.purchaseId))
+  Fail -> do
+    st <- H.get
+    H.raise (SubmitDomainEvent (FailPurchase st.purchaseId))
+  GoBack -> H.raise NavigateBack

--- a/client/src/View/Types.purs
+++ b/client/src/View/Types.purs
@@ -1,0 +1,76 @@
+module View.Types
+  ( Screen(..)
+  , Identity
+  , AppState
+  , AppAction(..)
+  , initialState
+  ) where
+
+import Prelude
+
+import Data.Maybe (Maybe(..))
+import Domain.State (GroupState)
+import Domain.State as DS
+import Domain.Types (MemberId, PurchaseId)
+import FFI.TweetNaCl (KeyPair)
+import FFI.WebSocket (WebSocket)
+
+-- | Identity: keypair + AID prefix
+type Identity =
+  { keyPair :: KeyPair
+  , prefix :: String
+  , memberId :: MemberId
+  }
+
+-- | Navigation screens
+data Screen
+  = IdentityScreen
+  | DashboardScreen
+  | MembersScreen
+  | WalletScreen
+  | PurchaseScreen PurchaseId
+
+derive instance eqScreen :: Eq Screen
+
+-- | Root application state
+type AppState =
+  { screen :: Screen
+  , identity :: Maybe Identity
+  , groupId :: Maybe String
+  , groupState :: GroupState
+  , sequenceNumber :: Int
+  , ws :: Maybe WebSocket
+  , error :: Maybe String
+  , inputValue :: String
+  , inputAmount :: String
+  }
+
+initialState :: AppState
+initialState =
+  { screen: IdentityScreen
+  , identity: Nothing
+  , groupId: Nothing
+  , groupState: DS.emptyState
+  , sequenceNumber: 0
+  , ws: Nothing
+  , error: Nothing
+  , inputValue: ""
+  , inputAmount: ""
+  }
+
+-- | Application actions
+data AppAction
+  = Initialize
+  | Navigate Screen
+  | SetInputValue String
+  | SetInputAmount String
+  | GenerateIdentity
+  | IdentityLoaded Identity
+  | CreateGroup
+  | JoinGroup String
+  | GroupJoined String
+  | SubmitEvent
+  | EventAppended
+  | EventReceived String
+  | SetError String
+  | ClearError

--- a/client/src/View/Wallet.purs
+++ b/client/src/View/Wallet.purs
@@ -1,0 +1,139 @@
+module View.Wallet
+  ( walletComponent
+  , Output(..)
+  , Input
+  ) where
+
+import Prelude
+
+import Data.Int as Int
+import Data.Map as Map
+import Data.Maybe (Maybe(..))
+import Data.Tuple (Tuple(..))
+import Domain.Event (DomainEvent(..))
+import Domain.State (GroupState)
+import Domain.Types (AID(..), Cents(..), MemberId(..), MemberName(..), Reason(..))
+import Halogen as H
+import Halogen.HTML as HH
+import Halogen.HTML.Events as HE
+import Halogen.HTML.Properties as HP
+
+type Input =
+  { groupState :: GroupState
+  , myId :: Maybe MemberId
+  }
+
+type State =
+  { groupState :: GroupState
+  , myId :: Maybe MemberId
+  , depositMember :: String
+  , depositAmount :: String
+  , withdrawMember :: String
+  , withdrawAmount :: String
+  , withdrawReason :: String
+  }
+
+data Action
+  = Receive Input
+  | SetDepositMember String
+  | SetDepositAmount String
+  | SetWithdrawMember String
+  | SetWithdrawAmount String
+  | SetWithdrawReason String
+  | SubmitDeposit
+  | SubmitWithdraw
+  | GoBack
+
+data Output
+  = SubmitDomainEvent DomainEvent
+  | NavigateBack
+
+walletComponent :: forall q m. H.Component q Input Output m
+walletComponent = H.mkComponent
+  { initialState: \i ->
+      { groupState: i.groupState
+      , myId: i.myId
+      , depositMember: ""
+      , depositAmount: ""
+      , withdrawMember: ""
+      , withdrawAmount: ""
+      , withdrawReason: ""
+      }
+  , render
+  , eval: H.mkEval H.defaultEval
+      { receive = Just <<< Receive
+      , handleAction = handleAction
+      }
+  }
+
+render :: forall m. State -> H.ComponentHTML Action () m
+render st = HH.div [ HP.class_ (HH.ClassName "wallet") ]
+  [ HH.button [ HE.onClick (const GoBack) ] [ HH.text "Back" ]
+  , HH.h2_ [ HH.text "Wallet" ]
+  , HH.h3_ [ HH.text "Balances" ]
+  , HH.table_
+      [ HH.thead_
+          [ HH.tr_
+              [ HH.th_ [ HH.text "Member" ]
+              , HH.th_ [ HH.text "Balance" ]
+              ]
+          ]
+      , HH.tbody_ (map renderBalance balances)
+      ]
+  , HH.h3_ [ HH.text "Deposit" ]
+  , HH.div [ HP.class_ (HH.ClassName "form") ]
+      [ HH.input [ HP.placeholder "Member AID", HP.value st.depositMember, HE.onValueInput SetDepositMember ]
+      , HH.input [ HP.placeholder "Amount (cents)", HP.value st.depositAmount, HE.onValueInput SetDepositAmount ]
+      , HH.button [ HE.onClick (const SubmitDeposit) ] [ HH.text "Deposit" ]
+      ]
+  , HH.h3_ [ HH.text "Withdraw" ]
+  , HH.div [ HP.class_ (HH.ClassName "form") ]
+      [ HH.input [ HP.placeholder "Member AID", HP.value st.withdrawMember, HE.onValueInput SetWithdrawMember ]
+      , HH.input [ HP.placeholder "Amount (cents)", HP.value st.withdrawAmount, HE.onValueInput SetWithdrawAmount ]
+      , HH.input [ HP.placeholder "Reason", HP.value st.withdrawReason, HE.onValueInput SetWithdrawReason ]
+      , HH.button [ HE.onClick (const SubmitWithdraw) ] [ HH.text "Withdraw" ]
+      ]
+  ]
+  where
+  balances :: Array (Tuple MemberId Cents)
+  balances = Map.toUnfoldable st.groupState.balances
+
+  renderBalance (Tuple mid (Cents cents)) =
+    let
+      name = case Map.lookup mid st.groupState.members of
+        Just (MemberName n) -> n
+        Nothing -> show mid
+    in
+      HH.tr_
+        [ HH.td_ [ HH.text name ]
+        , HH.td_ [ HH.text (show cents) ]
+        ]
+
+handleAction :: forall m. Action -> H.HalogenM State Action () Output m Unit
+handleAction = case _ of
+  Receive i -> H.modify_ _ { groupState = i.groupState, myId = i.myId }
+  SetDepositMember s -> H.modify_ _ { depositMember = s }
+  SetDepositAmount s -> H.modify_ _ { depositAmount = s }
+  SetWithdrawMember s -> H.modify_ _ { withdrawMember = s }
+  SetWithdrawAmount s -> H.modify_ _ { withdrawAmount = s }
+  SetWithdrawReason s -> H.modify_ _ { withdrawReason = s }
+  SubmitDeposit -> do
+    st <- H.get
+    case Int.fromString st.depositAmount of
+      Just cents -> do
+        let mid = parseMemberId st.depositMember
+        H.raise (SubmitDomainEvent (Deposit mid (Cents cents)))
+        H.modify_ _ { depositMember = "", depositAmount = "" }
+      Nothing -> pure unit
+  SubmitWithdraw -> do
+    st <- H.get
+    case Int.fromString st.withdrawAmount of
+      Just cents -> do
+        let mid = parseMemberId st.withdrawMember
+        H.raise (SubmitDomainEvent (Withdraw mid (Cents cents) (Reason st.withdrawReason)))
+        H.modify_ _ { withdrawMember = "", withdrawAmount = "", withdrawReason = "" }
+      Nothing -> pure unit
+  GoBack -> H.raise NavigateBack
+
+parseMemberId :: String -> MemberId
+parseMemberId s = MemberId (AID s)


### PR DESCRIPTION
## Summary

- Root `App` component with screen routing and slot management
- `Identity` screen: Ed25519 keypair generation, CESR-encoded AID, localStorage persistence
- `Dashboard`: group overview with stats, open purchases list, navigation
- `Members`: register members, elect referente/cassiere, role display
- `Wallet`: balance table, deposit/withdraw forms
- `Purchase`: full lifecycle — commitments, approve/reject, vote close/fail, close/fail
- Comprehensive CSS styles for all components

## Test plan

- [ ] `just ci` passes (Haskell build + PureScript lint/build/bundle)
- [ ] `just serve` loads UI in browser
- [ ] Generate identity → navigates to dashboard
- [ ] Create/join group flow works
- [ ] Navigation between screens works