### PR TITLE
feat: Phase 5 — protocol wiring, README, blake2b fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,15 +2,58 @@
 
 KERI-based collective purchasing (GAS) application.
 
+Browser-based solidarity purchasing group where members manage identities,
+credit balances, and collective purchases — all signed with KERI Ed25519 keys.
+The server is a dumb append-only relay; clients verify everything.
+
+## Features
+
+- **KERI identity** — Ed25519 keypair generation, CESR encoding, key state machine
+- **Event sourcing** — all state derived by replaying a signed event log
+- **Governance** — admin voting (referente + cassiere roles) with majority quorum
+- **Purchases** — open, commit, approve/reject, vote close/fail lifecycle
+- **Wallet** — credit balances, deposits, withdrawals
+- **Zero trust** — server stores and forwards; clients sign and verify
+
 ## Development
 
 ```bash
 nix develop
-just build    # Haskell server
+just --list   # see all recipes
+just ci       # lint + build + bundle
 just serve    # server + client on :3001
 ```
 
 ## Architecture
 
-- **Server (Haskell):** Dumb append-only event log relay (Warp + SQLite)
-- **Client (PureScript):** All crypto client-side, KERI identity, domain logic
+```
+Browser ──┐                                    ┌── Browser
+          ├── HTTP + WebSocket ── Haskell Server ──┤
+Browser ──┘    (Warp + SQLite)                 └── Browser
+```
+
+- **Server (Haskell):** ~200 lines. Warp + wai-websockets + sqlite-simple.
+  Append-only log per group, WebSocket push, static file serving.
+- **Client (PureScript/Halogen):** KERI crypto, domain model, protocol layer, UI.
+  Keys in localStorage.
+
+## API
+
+```
+POST   /api/groups                     create group
+GET    /api/groups/:id/events?after=N  fetch events after seq N
+POST   /api/groups/:id/events          append event (409 on seq conflict)
+WS     /ws/groups/:id                  real-time push
+GET    /*                              static files (client bundle)
+```
+
+## Docker
+
+```bash
+just docker                    # build image via nix
+docker run -p 3001:3001 -v ./data:/data ghcr.io/paolino/keri-coop:dev
+```
+
+## Documentation
+
+Full docs at [paolino.github.io/keri-coop](https://paolino.github.io/keri-coop/).

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -6,15 +6,14 @@
     "": {
       "name": "keri-coop-client",
       "dependencies": {
-        "blake3": "^2.1.7",
+        "blakejs": "^1.2.1",
         "tweetnacl": "^1.0.3"
       }
     },
-    "node_modules/blake3": {
-      "version": "2.1.7",
-      "resolved": "https://registry.npmjs.org/blake3/-/blake3-2.1.7.tgz",
-      "integrity": "sha512-5d+TdKJvju96IyEaGJ0eO6CHbckWi+NBrCezGYM/WsnI3R03aLL2TWfsuZSh1rs0fTv/L3ps/r0vykjYurcIwA==",
-      "hasInstallScript": true,
+    "node_modules/blakejs": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.2.1.tgz",
+      "integrity": "sha512-QXUSXI3QVc/gJME0dBpXrag1kbzOqCjCX8/b54ntNyW6sjtoqxqRk3LTmXzaJoh71zMsDCjM+47jS7XiwN/+fQ==",
       "license": "MIT"
     },
     "node_modules/tweetnacl": {

--- a/client/package.json
+++ b/client/package.json
@@ -3,6 +3,6 @@
   "private": true,
   "dependencies": {
     "tweetnacl": "^1.0.3",
-    "blake3": "^2.1.7"
+    "blakejs": "^1.2.1"
   }
 }

--- a/client/src/FFI/Blake3.js
+++ b/client/src/FFI/Blake3.js
@@ -1,3 +1,3 @@
-import { hash } from "blake3/browser";
+import blakejs from "blakejs";
 
-export const hashImpl = (bytes) => hash(bytes);
+export const hashImpl = (bytes) => new Uint8Array(blakejs.blake2b(bytes, null, 32));


### PR DESCRIPTION
## Summary

- Wire `SubmitEvent` in App.purs to sign via Protocol.Message and send via Protocol.Client
- Apply signed events to local GroupState optimistically
- `CreateGroup` calls the server API
- Switch from `blake3` (WASM, breaks esbuild) to `blakejs` (pure JS blake2b, matches keri-hs)
- Expand README with features, architecture, API, docker, and docs links

## Test plan

- [ ] `just ci` passes (clean build + bundle)
- [ ] `just serve` loads UI, identity generation works
- [ ] Domain events are signed and sent to server when connected