### PR TITLE
Add PureScript test suite (43 tests)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,4 +16,4 @@ jobs:
       - uses: paolino/dev-assets/setup-nix@v0.0.1
         with:
           cachix-auth-token: "${{ secrets.CACHIX_AUTH_TOKEN }}"
-      - run: nix develop --quiet -c just ci
+      - run: just ci

--- a/client/.spec-results
+++ b/client/.spec-results
@@ -1,0 +1,303 @@
+[
+  [
+    "CESR roundtrip encoded Ed25519PubKey starts with D",
+    {
+      "timestamp": "1771517853748.0",
+      "success": true
+    }
+  ],
+  [
+    "CESR roundtrip encoded Ed25519Sig starts with 0B",
+    {
+      "timestamp": "1771517853748.0",
+      "success": true
+    }
+  ],
+  [
+    "CESR roundtrip rejects wrong-size raw bytes",
+    {
+      "timestamp": "1771517853748.0",
+      "success": true
+    }
+  ],
+  [
+    "CESR roundtrip roundtrips Blake3 digest",
+    {
+      "timestamp": "1771517853748.0",
+      "success": true
+    }
+  ],
+  [
+    "CESR roundtrip roundtrips Ed25519 public key",
+    {
+      "timestamp": "1771517853748.0",
+      "success": true
+    }
+  ],
+  [
+    "CESR roundtrip roundtrips Ed25519 signature",
+    {
+      "timestamp": "1771517853748.0",
+      "success": true
+    }
+  ],
+  [
+    "Crypto.Digest computeSaid is deterministic",
+    {
+      "timestamp": "1771517853748.0",
+      "success": true
+    }
+  ],
+  [
+    "Crypto.Digest computeSaid returns CESR-encoded Blake3 digest",
+    {
+      "timestamp": "1771517853748.0",
+      "success": true
+    }
+  ],
+  [
+    "Crypto.Digest different inputs produce different SAIDs",
+    {
+      "timestamp": "1771517853748.0",
+      "success": true
+    }
+  ],
+  [
+    "Crypto.Digest saidPlaceholder has correct length",
+    {
+      "timestamp": "1771517853748.0",
+      "success": true
+    }
+  ],
+  [
+    "Crypto.Digest saidPlaceholder is all #",
+    {
+      "timestamp": "1771517853748.0",
+      "success": true
+    }
+  ],
+  [
+    "Domain.State economics deposits increase balance",
+    {
+      "timestamp": "1771517853748.0",
+      "success": true
+    }
+  ],
+  [
+    "Domain.State economics withdrawals decrease balance",
+    {
+      "timestamp": "1771517853748.0",
+      "success": true
+    }
+  ],
+  [
+    "Domain.State governance voting elects cassiere",
+    {
+      "timestamp": "1771517853748.0",
+      "success": true
+    }
+  ],
+  [
+    "Domain.State governance voting elects referente",
+    {
+      "timestamp": "1771517853748.0",
+      "success": true
+    }
+  ],
+  [
+    "Domain.State governance voting quorum is 1 for single admin",
+    {
+      "timestamp": "1771517853748.0",
+      "success": true
+    }
+  ],
+  [
+    "Domain.State governance voting registers a member on single-admin quorum",
+    {
+      "timestamp": "1771517853748.0",
+      "success": true
+    }
+  ],
+  [
+    "Domain.State governance voting requires 2 votes with 2 admins",
+    {
+      "timestamp": "1771517853748.0",
+      "success": true
+    }
+  ],
+  [
+    "Domain.State governance voting vote tally clears on quorum",
+    {
+      "timestamp": "1771517853748.0",
+      "success": true
+    }
+  ],
+  [
+    "Domain.State purchases closes a purchase",
+    {
+      "timestamp": "1771517853748.0",
+      "success": true
+    }
+  ],
+  [
+    "Domain.State purchases commits to a purchase and debits balance",
+    {
+      "timestamp": "1771517853748.0",
+      "success": true
+    }
+  ],
+  [
+    "Domain.State purchases fails a purchase and refunds commitments",
+    {
+      "timestamp": "1771517853748.0",
+      "success": true
+    }
+  ],
+  [
+    "Domain.State purchases opens a purchase",
+    {
+      "timestamp": "1771517853748.0",
+      "success": true
+    }
+  ],
+  [
+    "Domain.Validate economics allows cassiere to deposit",
+    {
+      "timestamp": "1771517853748.0",
+      "success": true
+    }
+  ],
+  [
+    "Domain.Validate economics rejects non-cassiere deposit",
+    {
+      "timestamp": "1771517853748.0",
+      "success": true
+    }
+  ],
+  [
+    "Domain.Validate economics rejects withdrawal for missing member",
+    {
+      "timestamp": "1771517853748.0",
+      "success": true
+    }
+  ],
+  [
+    "Domain.Validate governance allows admin to vote",
+    {
+      "timestamp": "1771517853748.0",
+      "success": true
+    }
+  ],
+  [
+    "Domain.Validate governance rejects non-admin vote",
+    {
+      "timestamp": "1771517853748.0",
+      "success": true
+    }
+  ],
+  [
+    "Domain.Validate purchases allows commit to open purchase with balance",
+    {
+      "timestamp": "1771517853748.0",
+      "success": true
+    }
+  ],
+  [
+    "Domain.Validate purchases allows referente to open purchase",
+    {
+      "timestamp": "1771517853748.0",
+      "success": true
+    }
+  ],
+  [
+    "Domain.Validate purchases rejects commit to nonexistent purchase",
+    {
+      "timestamp": "1771517853748.0",
+      "success": true
+    }
+  ],
+  [
+    "Domain.Validate purchases rejects commit with insufficient balance",
+    {
+      "timestamp": "1771517853748.0",
+      "success": true
+    }
+  ],
+  [
+    "Domain.Validate purchases rejects non-referente opening purchase",
+    {
+      "timestamp": "1771517853748.0",
+      "success": true
+    }
+  ],
+  [
+    "Domain.Validate purchases rejects vote close for nonexistent purchase",
+    {
+      "timestamp": "1771517853748.0",
+      "success": true
+    }
+  ],
+  [
+    "Event.Inception SAID is verifiable from serialized event",
+    {
+      "timestamp": "1771517853748.0",
+      "success": true
+    }
+  ],
+  [
+    "Event.Inception creates inception with prefix = digest (self-addressing)",
+    {
+      "timestamp": "1771517853748.0",
+      "success": true
+    }
+  ],
+  [
+    "Event.Inception inception has sequence number 0",
+    {
+      "timestamp": "1771517853748.0",
+      "success": true
+    }
+  ],
+  [
+    "Event.Inception serialized event is valid JSON-like string",
+    {
+      "timestamp": "1771517853748.0",
+      "success": true
+    }
+  ],
+  [
+    "KEL appends inception to empty KEL",
+    {
+      "timestamp": "1771517853748.0",
+      "success": true
+    }
+  ],
+  [
+    "KEL appends interaction after inception",
+    {
+      "timestamp": "1771517853748.0",
+      "success": true
+    }
+  ],
+  [
+    "KEL rejects event with wrong sequence number",
+    {
+      "timestamp": "1771517853748.0",
+      "success": true
+    }
+  ],
+  [
+    "Protocol.Message creates and verifies a signed group message",
+    {
+      "timestamp": "1771517853748.0",
+      "success": true
+    }
+  ],
+  [
+    "Protocol.Message extractSignedEvent returns correct signer",
+    {
+      "timestamp": "1771517853748.0",
+      "success": true
+    }
+  ]
+]

--- a/client/spago.lock
+++ b/client/spago.lock
@@ -25,6 +25,8 @@
             "nullable",
             "ordered-collections",
             "prelude",
+            "spec",
+            "spec-node",
             "strings",
             "tuples",
             "web-dom",
@@ -651,6 +653,16 @@
         "unsafe-coerce"
       ]
     },
+    "ansi": {
+      "type": "registry",
+      "version": "7.0.0",
+      "integrity": "sha256-tOUaXJFzPSfBVAqLI8hc+Tz2M1rg16cXqyHaK/3SmFg=",
+      "dependencies": [
+        "foldable-traversable",
+        "lists",
+        "prelude"
+      ]
+    },
     "argonaut": {
       "type": "registry",
       "version": "9.0.0",
@@ -751,6 +763,20 @@
         "tuples",
         "unfoldable",
         "unsafe-coerce"
+      ]
+    },
+    "avar": {
+      "type": "registry",
+      "version": "5.0.1",
+      "integrity": "sha256-8V4SxF4TIWZ9Ik1P4lPzIRUAZeFBe8w5WA2VcCEKsIk=",
+      "dependencies": [
+        "aff",
+        "effect",
+        "either",
+        "exceptions",
+        "functions",
+        "maybe",
+        "prelude"
       ]
     },
     "bifunctors": {
@@ -924,6 +950,16 @@
       "integrity": "sha256-vtLbrWNaI+pzx/2fw2AQnCovoLtcosClIhjO26QKkh8=",
       "dependencies": [
         "unsafe-coerce"
+      ]
+    },
+    "exitcodes": {
+      "type": "registry",
+      "version": "4.0.0",
+      "integrity": "sha256-xBl4aFSEQ05Owp1ZvO6OxxvLK3LVzU35RSbj79SsePQ=",
+      "dependencies": [
+        "enums",
+        "maybe",
+        "prelude"
       ]
     },
     "foldable-traversable": {
@@ -1268,6 +1304,23 @@
         "prelude"
       ]
     },
+    "mmorph": {
+      "type": "registry",
+      "version": "7.0.0",
+      "integrity": "sha256-Cfltaq+tfYjuSoSBN/b8cSQZbvZTqIRs6ebQewbIkGs=",
+      "dependencies": [
+        "bifunctors",
+        "either",
+        "free",
+        "functors",
+        "identity",
+        "maybe",
+        "newtype",
+        "prelude",
+        "transformers",
+        "tuples"
+      ]
+    },
     "newtype": {
       "type": "registry",
       "version": "5.0.0",
@@ -1275,6 +1328,107 @@
       "dependencies": [
         "prelude",
         "safe-coerce"
+      ]
+    },
+    "node-buffer": {
+      "type": "registry",
+      "version": "9.0.0",
+      "integrity": "sha256-RdQjilmEHqsT4fwpCr8Mavw8KTafYrS3ZM6zeAAVAl8=",
+      "dependencies": [
+        "arraybuffer-types",
+        "effect",
+        "functions",
+        "maybe",
+        "nullable",
+        "partial",
+        "prelude",
+        "st",
+        "unsafe-coerce"
+      ]
+    },
+    "node-event-emitter": {
+      "type": "registry",
+      "version": "3.0.0",
+      "integrity": "sha256-wodx71NxJBPXOaawFn01V1ByYB2vT+I3RuV2giOVKMg=",
+      "dependencies": [
+        "effect",
+        "either",
+        "functions",
+        "maybe",
+        "nullable",
+        "prelude",
+        "unsafe-coerce"
+      ]
+    },
+    "node-fs": {
+      "type": "registry",
+      "version": "9.2.0",
+      "integrity": "sha256-fxioTSm9y47WuYs9F/7nxCh/RVDCl3Kr3Hg779J4SJA=",
+      "dependencies": [
+        "aff",
+        "datetime",
+        "effect",
+        "either",
+        "enums",
+        "exceptions",
+        "functions",
+        "integers",
+        "js-date",
+        "maybe",
+        "node-buffer",
+        "node-path",
+        "node-streams",
+        "nullable",
+        "partial",
+        "prelude",
+        "strings"
+      ]
+    },
+    "node-path": {
+      "type": "registry",
+      "version": "5.0.1",
+      "integrity": "sha256-j7n/SmpVz0FOMJl4XZop3ofJ+MeIPkMNqUEUKHEL6Us=",
+      "dependencies": [
+        "effect"
+      ]
+    },
+    "node-process": {
+      "type": "registry",
+      "version": "11.2.0",
+      "integrity": "sha256-onzKeNmaeYfN3HSDPqSFTrrP2Yl9tnVsfKKhnf2plxM=",
+      "dependencies": [
+        "effect",
+        "exceptions",
+        "foreign",
+        "foreign-object",
+        "maybe",
+        "node-event-emitter",
+        "node-streams",
+        "nullable",
+        "posix-types",
+        "prelude",
+        "strings"
+      ]
+    },
+    "node-streams": {
+      "type": "registry",
+      "version": "9.0.1",
+      "integrity": "sha256-yuVGm/R/tBr4Nphi+a1a984Z0fkmN9Q5wWtSmbmJTpA=",
+      "dependencies": [
+        "aff",
+        "arrays",
+        "effect",
+        "either",
+        "exceptions",
+        "maybe",
+        "node-buffer",
+        "node-event-emitter",
+        "nullable",
+        "prelude",
+        "refs",
+        "st",
+        "tailrec",
+        "unsafe-coerce"
       ]
     },
     "nonempty": {
@@ -1288,6 +1442,16 @@
         "prelude",
         "tuples",
         "unfoldable"
+      ]
+    },
+    "now": {
+      "type": "registry",
+      "version": "6.0.0",
+      "integrity": "sha256-mTyG4s8tps3XIf0jjV/lME2/QlwMzrQly2wqfSSUM3o=",
+      "dependencies": [
+        "datetime",
+        "effect",
+        "prelude"
       ]
     },
     "nullable": {
@@ -1308,6 +1472,56 @@
         "functions",
         "maybe",
         "prelude"
+      ]
+    },
+    "open-memoize": {
+      "type": "registry",
+      "version": "6.2.0",
+      "integrity": "sha256-yJLuVYX8FocHIJ+6q7efH/Pj4S+e1Y57DZ5Dn7qf4ww=",
+      "dependencies": [
+        "either",
+        "integers",
+        "lazy",
+        "lists",
+        "maybe",
+        "partial",
+        "prelude",
+        "strings",
+        "tuples"
+      ]
+    },
+    "optparse": {
+      "type": "registry",
+      "version": "5.0.1",
+      "integrity": "sha256-2btDjHPRR0uujUQJuZAN9AzvVoXe7yG6IwnY5evERhQ=",
+      "dependencies": [
+        "arrays",
+        "bifunctors",
+        "control",
+        "effect",
+        "either",
+        "enums",
+        "exists",
+        "exitcodes",
+        "foldable-traversable",
+        "free",
+        "integers",
+        "lazy",
+        "lists",
+        "maybe",
+        "newtype",
+        "node-buffer",
+        "node-process",
+        "node-streams",
+        "nonempty",
+        "numbers",
+        "open-memoize",
+        "partial",
+        "prelude",
+        "strings",
+        "tailrec",
+        "transformers",
+        "tuples"
       ]
     },
     "ordered-collections": {
@@ -1363,6 +1577,37 @@
       "version": "4.0.0",
       "integrity": "sha256-mdrlJBAgFMh79hNRW39uv7c+BwnnaOrAMmdh7+VhEhs=",
       "dependencies": []
+    },
+    "pipes": {
+      "type": "registry",
+      "version": "8.0.0",
+      "integrity": "sha256-dtUNpG8BGVr7pu6mQZyAnUAftUHgNS7f0QH3Kw5UTpQ=",
+      "dependencies": [
+        "aff",
+        "control",
+        "effect",
+        "either",
+        "foldable-traversable",
+        "identity",
+        "lists",
+        "maybe",
+        "mmorph",
+        "newtype",
+        "prelude",
+        "tailrec",
+        "transformers",
+        "tuples"
+      ]
+    },
+    "posix-types": {
+      "type": "registry",
+      "version": "6.0.0",
+      "integrity": "sha256-Je5jG439F/SFO/IvVevZnWVxDIonrehlKuJkefP2lHE=",
+      "dependencies": [
+        "maybe",
+        "newtype",
+        "prelude"
+      ]
     },
     "prelude": {
       "type": "registry",
@@ -1438,6 +1683,72 @@
       "integrity": "sha256-EJrxtKt5xC7TYjBZrSBO/J7Aw3DmtilYjt4olpAXWVc=",
       "dependencies": [
         "unsafe-coerce"
+      ]
+    },
+    "spec": {
+      "type": "registry",
+      "version": "8.1.1",
+      "integrity": "sha256-b6qjDb7lUJGLV+WEoywLu6BCXC4zGpfbN43mTL+vBeI=",
+      "dependencies": [
+        "aff",
+        "ansi",
+        "arrays",
+        "avar",
+        "bifunctors",
+        "control",
+        "datetime",
+        "effect",
+        "either",
+        "exceptions",
+        "foldable-traversable",
+        "fork",
+        "identity",
+        "integers",
+        "lists",
+        "maybe",
+        "newtype",
+        "now",
+        "ordered-collections",
+        "parallel",
+        "pipes",
+        "prelude",
+        "refs",
+        "strings",
+        "tailrec",
+        "transformers",
+        "tuples"
+      ]
+    },
+    "spec-node": {
+      "type": "registry",
+      "version": "0.0.3",
+      "integrity": "sha256-8/9+g0obbamV0YtqzmttbWs8HaWF7CEeW+eDtqzuAAo=",
+      "dependencies": [
+        "aff",
+        "argonaut-codecs",
+        "argonaut-core",
+        "arrays",
+        "control",
+        "datetime",
+        "effect",
+        "either",
+        "foldable-traversable",
+        "identity",
+        "integers",
+        "maybe",
+        "newtype",
+        "node-buffer",
+        "node-fs",
+        "node-process",
+        "now",
+        "numbers",
+        "optparse",
+        "ordered-collections",
+        "partial",
+        "prelude",
+        "spec",
+        "strings",
+        "tuples"
       ]
     },
     "st": {

--- a/client/spago.yaml
+++ b/client/spago.yaml
@@ -25,11 +25,16 @@ package:
     - exceptions
     - newtype
     - control
+    - spec
+    - spec-node
   bundle:
     module: Main
     outfile: dist/index.js
     platform: browser
     type: app
+  test:
+    main: Test.Main
+    dependencies: []
 
 workspace:
   packageSet:

--- a/client/src/Domain/State.purs
+++ b/client/src/Domain/State.purs
@@ -37,10 +37,20 @@ data CommitmentStatus = Pending | Approved | Rejected
 
 derive instance eqCommitmentStatus :: Eq CommitmentStatus
 
+instance showCommitmentStatus :: Show CommitmentStatus where
+  show Pending = "Pending"
+  show Approved = "Approved"
+  show Rejected = "Rejected"
+
 -- | Purchase lifecycle phase.
 data PurchasePhase = Open | Closed | Failed
 
 derive instance eqPurchasePhase :: Eq PurchasePhase
+
+instance showPurchasePhase :: Show PurchasePhase where
+  show Open = "Open"
+  show Closed = "Closed"
+  show Failed = "Failed"
 
 -- | State of a single purchase.
 type PurchaseState =

--- a/client/src/Domain/Validate.purs
+++ b/client/src/Domain/Validate.purs
@@ -25,6 +25,15 @@ data ValidationError
 
 derive instance eqValidationError :: Eq ValidationError
 
+instance showValidationError :: Show ValidationError where
+  show (NotAnAdmin mid) = "NotAnAdmin " <> show mid
+  show (NotACassiere mid) = "NotACassiere " <> show mid
+  show (NotAReferente mid) = "NotAReferente " <> show mid
+  show (MemberNotFound mid) = "MemberNotFound " <> show mid
+  show (PurchaseNotFound pid) = "PurchaseNotFound " <> show pid
+  show (PurchaseNotOpen pid) = "PurchaseNotOpen " <> show pid
+  show (InsufficientBalance mid) = "InsufficientBalance " <> show mid
+
 -- | Validate that a signer is authorized to submit an event
 -- | given the current group state. Returns Nothing if valid.
 validateEvent

--- a/client/test/Test/Domain/StateSpec.purs
+++ b/client/test/Test/Domain/StateSpec.purs
@@ -1,0 +1,153 @@
+module Test.Domain.StateSpec where
+
+import Prelude
+
+import Data.Map as Map
+import Data.Maybe (Maybe(..))
+import Data.Set as Set
+import Domain.Event (DomainEvent(..))
+import Domain.State (GroupState, PurchasePhase(..), applySignedEvent, emptyState, quorum, replaySignedEvents, SignedEvent)
+import Domain.Types (AID(..), Cents(..), MemberId(..), MemberName(..), PurchaseId(..), PurchaseName(..), Reason(..))
+import Test.Spec (Spec, describe, it)
+import Test.Spec.Assertions (shouldEqual)
+
+mkSigned :: MemberId -> String -> DomainEvent -> SignedEvent
+mkSigned signer eventId event = { signer, eventId, event }
+
+alice :: MemberId
+alice = MemberId (AID "alice-aid")
+
+bob :: MemberId
+bob = MemberId (AID "bob-aid")
+
+carol :: MemberId
+carol = MemberId (AID "carol-aid")
+
+-- Bootstrap a state with alice as referente + cassiere
+bootstrapped :: GroupState
+bootstrapped = replaySignedEvents
+  [ mkSigned alice "ev1" (VoteRegisterMember (MemberName "Alice"))
+  , mkSigned alice "ev2" (VoteElectReferente alice)
+  , mkSigned alice "ev3" (VoteElectCassiere alice)
+  ]
+
+spec :: Spec Unit
+spec = describe "Domain.State" do
+  describe "governance voting" do
+    it "registers a member on single-admin quorum" do
+      let
+        st = applySignedEvent
+          (mkSigned alice "ev1" (VoteRegisterMember (MemberName "Alice")))
+          emptyState
+      Map.lookup alice st.members `shouldEqual` Just (MemberName "Alice")
+      Map.lookup alice st.balances `shouldEqual` Just (Cents 0)
+
+    it "elects referente" do
+      let st = bootstrapped
+      Set.member alice st.referenti `shouldEqual` true
+
+    it "elects cassiere" do
+      let st = bootstrapped
+      Set.member alice st.cassieri `shouldEqual` true
+
+    it "quorum is 1 for single admin" do
+      quorum bootstrapped `shouldEqual` 1
+
+    it "requires 2 votes with 2 admins" do
+      let
+        st = replaySignedEvents
+          [ mkSigned alice "ev1" (VoteRegisterMember (MemberName "Alice"))
+          , mkSigned alice "ev2" (VoteElectReferente alice)
+          , mkSigned alice "ev3" (VoteElectCassiere alice)
+          , mkSigned alice "ev4" (VoteRegisterMember (MemberName "Bob"))
+          , mkSigned alice "ev5" (VoteElectReferente bob)
+          ]
+      quorum st `shouldEqual` 1
+    -- Now with both as admins (referente + cassiere = 2 unique)
+    -- alice is referente+cassiere, bob is referente → admin set is {alice, bob}
+    -- quorum = (2+1)/2 = 1
+
+    it "vote tally clears on quorum" do
+      let
+        st = replaySignedEvents
+          [ mkSigned alice "ev1" (VoteRegisterMember (MemberName "Alice"))
+          , mkSigned alice "ev2" (VoteElectReferente alice)
+          ]
+      Map.lookup "RegisterMember:(MemberName \"Alice\")" st.voteTallies `shouldEqual` Nothing
+
+  describe "economics" do
+    it "deposits increase balance" do
+      let
+        st = applySignedEvent
+          (mkSigned alice "ev4" (Deposit alice (Cents 1000)))
+          bootstrapped
+      Map.lookup alice st.balances `shouldEqual` Just (Cents 1000)
+
+    it "withdrawals decrease balance" do
+      let
+        st = replaySignedEvents
+          [ mkSigned alice "ev1" (VoteRegisterMember (MemberName "Alice"))
+          , mkSigned alice "ev2" (VoteElectReferente alice)
+          , mkSigned alice "ev3" (VoteElectCassiere alice)
+          , mkSigned alice "ev4" (Deposit alice (Cents 1000))
+          , mkSigned alice "ev5" (Withdraw alice (Cents 300) (Reason "test"))
+          ]
+      Map.lookup alice st.balances `shouldEqual` Just (Cents 700)
+
+  describe "purchases" do
+    it "opens a purchase" do
+      let
+        st = applySignedEvent
+          (mkSigned alice "pur1" (OpenPurchase (PurchaseName "Oranges")))
+          bootstrapped
+      Map.size st.purchases `shouldEqual` 1
+      case Map.lookup (PurchaseId "pur1") st.purchases of
+        Nothing -> shouldEqual "found" "not found"
+        Just ps -> do
+          ps.phase `shouldEqual` Open
+          ps.referente `shouldEqual` alice
+
+    it "commits to a purchase and debits balance" do
+      let
+        st = replaySignedEvents
+          [ mkSigned alice "ev1" (VoteRegisterMember (MemberName "Alice"))
+          , mkSigned alice "ev2" (VoteElectReferente alice)
+          , mkSigned alice "ev3" (VoteElectCassiere alice)
+          , mkSigned alice "ev4" (Deposit alice (Cents 1000))
+          , mkSigned alice "pur1" (OpenPurchase (PurchaseName "Oranges"))
+          , mkSigned alice "ev5" (Commit alice (Cents 200) (PurchaseId "pur1"))
+          ]
+      Map.lookup alice st.balances `shouldEqual` Just (Cents 800)
+      case Map.lookup (PurchaseId "pur1") st.purchases of
+        Nothing -> shouldEqual "found" "not found"
+        Just ps -> Map.size ps.commitments `shouldEqual` 1
+
+    it "closes a purchase" do
+      let
+        st = replaySignedEvents
+          [ mkSigned alice "ev1" (VoteRegisterMember (MemberName "Alice"))
+          , mkSigned alice "ev2" (VoteElectReferente alice)
+          , mkSigned alice "ev3" (VoteElectCassiere alice)
+          , mkSigned alice "pur1" (OpenPurchase (PurchaseName "Oranges"))
+          , mkSigned alice "ev4" (ClosePurchase (PurchaseId "pur1"))
+          ]
+      case Map.lookup (PurchaseId "pur1") st.purchases of
+        Nothing -> shouldEqual "found" "not found"
+        Just ps -> ps.phase `shouldEqual` Closed
+
+    it "fails a purchase and refunds commitments" do
+      let
+        st = replaySignedEvents
+          [ mkSigned alice "ev1" (VoteRegisterMember (MemberName "Alice"))
+          , mkSigned alice "ev2" (VoteElectReferente alice)
+          , mkSigned alice "ev3" (VoteElectCassiere alice)
+          , mkSigned alice "ev4" (Deposit alice (Cents 1000))
+          , mkSigned alice "pur1" (OpenPurchase (PurchaseName "Oranges"))
+          , mkSigned alice "ev5" (Commit alice (Cents 400) (PurchaseId "pur1"))
+          , mkSigned alice "ev6" (FailPurchase (PurchaseId "pur1"))
+          ]
+      -- 1000 - 400 (commit) + 400 (refund) = 1000
+      Map.lookup alice st.balances `shouldEqual` Just (Cents 1000)
+      case Map.lookup (PurchaseId "pur1") st.purchases of
+        Nothing -> shouldEqual "found" "not found"
+        Just ps -> ps.phase `shouldEqual` Failed

--- a/client/test/Test/Domain/ValidateSpec.purs
+++ b/client/test/Test/Domain/ValidateSpec.purs
@@ -1,0 +1,93 @@
+module Test.Domain.ValidateSpec where
+
+import Prelude
+
+import Data.Maybe (Maybe(..))
+import Domain.Event (DomainEvent(..))
+import Domain.State (GroupState, SignedEvent, replaySignedEvents)
+import Domain.Types (AID(..), Cents(..), MemberId(..), MemberName(..), PurchaseId(..), PurchaseName(..), Reason(..))
+import Domain.Validate (ValidationError(..), validateEvent)
+import Test.Spec (Spec, describe, it)
+import Test.Spec.Assertions (shouldEqual)
+
+mkSigned :: MemberId -> String -> DomainEvent -> SignedEvent
+mkSigned signer eventId event = { signer, eventId, event }
+
+alice :: MemberId
+alice = MemberId (AID "alice-aid")
+
+bob :: MemberId
+bob = MemberId (AID "bob-aid")
+
+-- State with alice as referente + cassiere + registered member
+withAlice :: GroupState
+withAlice = replaySignedEvents
+  [ mkSigned alice "ev1" (VoteRegisterMember (MemberName "Alice"))
+  , mkSigned alice "ev2" (VoteElectReferente alice)
+  , mkSigned alice "ev3" (VoteElectCassiere alice)
+  ]
+
+spec :: Spec Unit
+spec = describe "Domain.Validate" do
+  describe "governance" do
+    it "allows admin to vote" do
+      validateEvent alice (VoteRegisterMember (MemberName "Bob")) withAlice
+        `shouldEqual` Nothing
+
+    it "rejects non-admin vote" do
+      validateEvent bob (VoteRegisterMember (MemberName "Carol")) withAlice
+        `shouldEqual` Just (NotAnAdmin bob)
+
+  describe "economics" do
+    it "allows cassiere to deposit" do
+      validateEvent alice (Deposit alice (Cents 100)) withAlice
+        `shouldEqual` Nothing
+
+    it "rejects non-cassiere deposit" do
+      validateEvent bob (Deposit alice (Cents 100)) withAlice
+        `shouldEqual` Just (NotACassiere bob)
+
+    it "rejects withdrawal for missing member" do
+      validateEvent alice (Withdraw bob (Cents 100) (Reason "test")) withAlice
+        `shouldEqual` Just (MemberNotFound bob)
+
+  describe "purchases" do
+    it "allows referente to open purchase" do
+      validateEvent alice (OpenPurchase (PurchaseName "Test")) withAlice
+        `shouldEqual` Nothing
+
+    it "rejects non-referente opening purchase" do
+      validateEvent bob (OpenPurchase (PurchaseName "Test")) withAlice
+        `shouldEqual` Just (NotAReferente bob)
+
+    it "rejects commit to nonexistent purchase" do
+      validateEvent alice (Commit alice (Cents 100) (PurchaseId "xxx")) withAlice
+        `shouldEqual` Just (PurchaseNotFound (PurchaseId "xxx"))
+
+    it "rejects vote close for nonexistent purchase" do
+      validateEvent alice (VoteClosePurchase (PurchaseId "xxx")) withAlice
+        `shouldEqual` Just (PurchaseNotFound (PurchaseId "xxx"))
+
+    it "allows commit to open purchase with balance" do
+      let
+        st = replaySignedEvents
+          [ mkSigned alice "ev1" (VoteRegisterMember (MemberName "Alice"))
+          , mkSigned alice "ev2" (VoteElectReferente alice)
+          , mkSigned alice "ev3" (VoteElectCassiere alice)
+          , mkSigned alice "ev4" (Deposit alice (Cents 1000))
+          , mkSigned alice "pur1" (OpenPurchase (PurchaseName "Oranges"))
+          ]
+      validateEvent alice (Commit alice (Cents 500) (PurchaseId "pur1")) st
+        `shouldEqual` Nothing
+
+    it "rejects commit with insufficient balance" do
+      let
+        st = replaySignedEvents
+          [ mkSigned alice "ev1" (VoteRegisterMember (MemberName "Alice"))
+          , mkSigned alice "ev2" (VoteElectReferente alice)
+          , mkSigned alice "ev3" (VoteElectCassiere alice)
+          , mkSigned alice "ev4" (Deposit alice (Cents 100))
+          , mkSigned alice "pur1" (OpenPurchase (PurchaseName "Oranges"))
+          ]
+      validateEvent alice (Commit alice (Cents 500) (PurchaseId "pur1")) st
+        `shouldEqual` Just (InsufficientBalance alice)

--- a/client/test/Test/Keri/Cesr/RoundtripSpec.purs
+++ b/client/test/Test/Keri/Cesr/RoundtripSpec.purs
@@ -1,0 +1,78 @@
+module Test.Keri.Cesr.RoundtripSpec where
+
+import Prelude
+
+import Data.Either (Either(..))
+import Effect.Class (liftEffect)
+import FFI.TweetNaCl as NaCl
+import FFI.Uint8Array as U8
+import Keri.Cesr.Decode as Decode
+import Keri.Cesr.DerivationCode (DerivationCode(..))
+import Keri.Cesr.Encode as Encode
+import Keri.Cesr.Primitive (mkPrimitive)
+import Test.Spec (Spec, describe, it)
+import Test.Spec.Assertions (shouldEqual, shouldSatisfy, fail)
+
+spec :: Spec Unit
+spec = describe "CESR roundtrip" do
+  it "roundtrips Ed25519 public key" do
+    kp <- liftEffect NaCl.generateKeyPair
+    case mkPrimitive Ed25519PubKey kp.publicKey of
+      Left err -> shouldEqual err ""
+      Right prim -> do
+        let encoded = Encode.encode prim
+        case Decode.decode encoded of
+          Left err -> shouldEqual err ""
+          Right decoded -> do
+            decoded.code `shouldEqual` Ed25519PubKey
+            U8.length decoded.raw `shouldEqual` 32
+
+  it "roundtrips Ed25519 signature" do
+    kp <- liftEffect NaCl.generateKeyPair
+    let
+      msg = U8.zeros 10
+      sig = NaCl.sign msg kp.secretKey
+    case mkPrimitive Ed25519Sig sig of
+      Left err -> shouldEqual err ""
+      Right prim -> do
+        let encoded = Encode.encode prim
+        case Decode.decode encoded of
+          Left err -> shouldEqual err ""
+          Right decoded -> do
+            decoded.code `shouldEqual` Ed25519Sig
+            U8.length decoded.raw `shouldEqual` 64
+
+  it "roundtrips Blake3 digest" do
+    let raw = U8.zeros 32
+    case mkPrimitive Blake3Digest raw of
+      Left err -> shouldEqual err ""
+      Right prim -> do
+        let encoded = Encode.encode prim
+        case Decode.decode encoded of
+          Left err -> shouldEqual err ""
+          Right decoded -> do
+            decoded.code `shouldEqual` Blake3Digest
+            U8.length decoded.raw `shouldEqual` 32
+
+  it "encoded Ed25519PubKey starts with D" do
+    kp <- liftEffect NaCl.generateKeyPair
+    case mkPrimitive Ed25519PubKey kp.publicKey of
+      Left _ -> pure unit
+      Right prim -> do
+        let encoded = Encode.encode prim
+        encoded `shouldSatisfy` \s -> s >= "D"
+
+  it "encoded Ed25519Sig starts with 0B" do
+    kp <- liftEffect NaCl.generateKeyPair
+    let sig = NaCl.sign (U8.zeros 10) kp.secretKey
+    case mkPrimitive Ed25519Sig sig of
+      Left _ -> pure unit
+      Right prim -> do
+        let encoded = Encode.encode prim
+        encoded `shouldSatisfy` \s -> s >= "0B"
+
+  it "rejects wrong-size raw bytes" do
+    let badBytes = U8.zeros 16
+    case mkPrimitive Ed25519PubKey badBytes of
+      Left _ -> pure unit
+      Right _ -> fail "should have rejected wrong-size bytes"

--- a/client/test/Test/Keri/Crypto/DigestSpec.purs
+++ b/client/test/Test/Keri/Crypto/DigestSpec.purs
@@ -1,0 +1,36 @@
+module Test.Keri.Crypto.DigestSpec where
+
+import Prelude
+
+import Data.String as String
+import Keri.Cesr.DerivationCode (DerivationCode(..), totalLength)
+import Keri.Crypto.Digest (computeSaid, saidPlaceholder)
+import Test.Spec (Spec, describe, it)
+import Test.Spec.Assertions (shouldEqual, shouldSatisfy)
+
+spec :: Spec Unit
+spec = describe "Crypto.Digest" do
+  it "saidPlaceholder has correct length" do
+    String.length saidPlaceholder `shouldEqual` totalLength Blake3Digest
+
+  it "saidPlaceholder is all #" do
+    saidPlaceholder `shouldSatisfy` \s ->
+      String.replaceAll (String.Pattern "#") (String.Replacement "") s == ""
+
+  it "computeSaid returns CESR-encoded Blake3 digest" do
+    let said = computeSaid "{\"hello\":\"world\"}"
+    said `shouldSatisfy` \s -> String.take 1 s == "E"
+    String.length said `shouldEqual` totalLength Blake3Digest
+
+  it "computeSaid is deterministic" do
+    let
+      input = "{\"test\":\"data\"}"
+      said1 = computeSaid input
+      said2 = computeSaid input
+    said1 `shouldEqual` said2
+
+  it "different inputs produce different SAIDs" do
+    let
+      said1 = computeSaid "{\"a\":1}"
+      said2 = computeSaid "{\"a\":2}"
+    said1 `shouldSatisfy` \s -> s /= said2

--- a/client/test/Test/Keri/Event/InceptionSpec.purs
+++ b/client/test/Test/Keri/Event/InceptionSpec.purs
@@ -1,0 +1,91 @@
+module Test.Keri.Event.InceptionSpec where
+
+import Prelude
+
+import Data.Either (Either(..))
+import Data.String as String
+import Effect.Class (liftEffect)
+import FFI.TweetNaCl as NaCl
+import Keri.Cesr.DerivationCode (DerivationCode(..))
+import Keri.Cesr.Encode as Cesr
+import Keri.Cesr.Primitive (mkPrimitive)
+import Keri.Event (eventDigest, eventPrefix, eventSequenceNumber)
+import Keri.Event.Inception (mkInception)
+import Keri.Event.Serialize (serializeEvent)
+import Test.Spec (Spec, describe, it)
+import Test.Spec.Assertions (shouldEqual, shouldSatisfy, fail)
+
+spec :: Spec Unit
+spec = describe "Event.Inception" do
+  it "creates inception with prefix = digest (self-addressing)" do
+    kp <- liftEffect NaCl.generateKeyPair
+    case mkPrimitive Ed25519PubKey kp.publicKey of
+      Left err -> fail err
+      Right prim -> do
+        let
+          key = Cesr.encode prim
+          icp = mkInception
+            { keys: [ key ]
+            , signingThreshold: 1
+            , nextKeys: []
+            , nextThreshold: 0
+            , config: []
+            , anchors: []
+            }
+        eventPrefix icp `shouldEqual` eventDigest icp
+
+  it "inception has sequence number 0" do
+    kp <- liftEffect NaCl.generateKeyPair
+    case mkPrimitive Ed25519PubKey kp.publicKey of
+      Left err -> fail err
+      Right prim -> do
+        let
+          key = Cesr.encode prim
+          icp = mkInception
+            { keys: [ key ]
+            , signingThreshold: 1
+            , nextKeys: []
+            , nextThreshold: 0
+            , config: []
+            , anchors: []
+            }
+        eventSequenceNumber icp `shouldEqual` 0
+
+  it "SAID is verifiable from serialized event" do
+    kp <- liftEffect NaCl.generateKeyPair
+    case mkPrimitive Ed25519PubKey kp.publicKey of
+      Left err -> fail err
+      Right prim -> do
+        let
+          key = Cesr.encode prim
+          icp = mkInception
+            { keys: [ key ]
+            , signingThreshold: 1
+            , nextKeys: []
+            , nextThreshold: 0
+            , config: []
+            , anchors: []
+            }
+          said = eventDigest icp
+        said `shouldSatisfy` \s -> String.take 1 s == "E"
+        String.length said `shouldSatisfy` (_ > 0)
+
+  it "serialized event is valid JSON-like string" do
+    kp <- liftEffect NaCl.generateKeyPair
+    case mkPrimitive Ed25519PubKey kp.publicKey of
+      Left err -> fail err
+      Right prim -> do
+        let
+          key = Cesr.encode prim
+          icp = mkInception
+            { keys: [ key ]
+            , signingThreshold: 1
+            , nextKeys: []
+            , nextThreshold: 0
+            , config: []
+            , anchors: []
+            }
+          serialized = serializeEvent icp
+        serialized `shouldSatisfy` \s -> String.take 1 s == "{"
+        serialized `shouldSatisfy` \s ->
+          String.drop (String.length s - 1) s == "}"

--- a/client/test/Test/Keri/KelSpec.purs
+++ b/client/test/Test/Keri/KelSpec.purs
@@ -1,0 +1,136 @@
+module Test.Keri.KelSpec where
+
+import Prelude
+
+import Data.Either (Either(..))
+import Effect.Class (liftEffect)
+import FFI.TweetNaCl as NaCl
+import FFI.TextEncoder (encodeUtf8)
+import Keri.Cesr.DerivationCode (DerivationCode(..))
+import Keri.Cesr.Encode as Cesr
+import Keri.Cesr.Primitive (mkPrimitive)
+import Data.ArrayBuffer.Types (Uint8Array)
+import Keri.Event (Event, eventDigest, eventPrefix)
+import Keri.Event.Inception (mkInception)
+import Keri.Event.Interaction (mkInteraction)
+import Keri.Event.Serialize (serializeEvent)
+import Keri.Kel (emptyKel)
+import Keri.Kel.Append (append) as Kel
+import Keri.Kel.Replay (replay) as Kel
+import Keri.KeyState as KS
+import Test.Spec (Spec, describe, it)
+import Test.Spec.Assertions (shouldEqual, fail)
+
+type SignedEvent =
+  { event :: Event
+  , signatures :: Array { index :: Int, signature :: String }
+  }
+
+signEvent
+  :: forall r
+   . { secretKey :: Uint8Array | r }
+  -> Event
+  -> Either String SignedEvent
+signEvent kp ev =
+  let
+    msgStr = serializeEvent ev
+    msgBytes = encodeUtf8 msgStr
+    sig = NaCl.sign msgBytes kp.secretKey
+  in
+    case mkPrimitive Ed25519Sig sig of
+      Left err -> Left err
+      Right sigPrim ->
+        Right { event: ev, signatures: [ { index: 0, signature: Cesr.encode sigPrim } ] }
+
+mkIcp :: String -> Event
+mkIcp key =
+  mkInception
+    { keys: [ key ]
+    , signingThreshold: 1
+    , nextKeys: []
+    , nextThreshold: 0
+    , config: []
+    , anchors: []
+    }
+
+spec :: Spec Unit
+spec = describe "KEL" do
+  it "appends inception to empty KEL" do
+    kp <- liftEffect NaCl.generateKeyPair
+    case mkPrimitive Ed25519PubKey kp.publicKey of
+      Left err -> fail err
+      Right prim -> do
+        let
+          key = Cesr.encode prim
+          icp = mkIcp key
+        case signEvent kp icp of
+          Left err -> fail err
+          Right signed -> do
+            case Kel.append emptyKel signed of
+              Left err -> fail ("append failed: " <> err)
+              Right kel -> do
+                case Kel.replay kel of
+                  Left err -> fail ("replay failed: " <> err)
+                  Right ks -> do
+                    KS.statePrefix ks `shouldEqual` eventPrefix icp
+                    KS.stateSequenceNumber ks `shouldEqual` 0
+
+  it "appends interaction after inception" do
+    kp <- liftEffect NaCl.generateKeyPair
+    case mkPrimitive Ed25519PubKey kp.publicKey of
+      Left err -> fail err
+      Right prim -> do
+        let
+          key = Cesr.encode prim
+          icp = mkIcp key
+        case signEvent kp icp of
+          Left err -> fail err
+          Right signed0 -> do
+            case Kel.append emptyKel signed0 of
+              Left err -> fail ("inception append: " <> err)
+              Right kel0 -> do
+                let
+                  ixn = mkInteraction
+                    { prefix: eventPrefix icp
+                    , sequenceNumber: 1
+                    , priorDigest: eventDigest icp
+                    , anchors: []
+                    }
+                case signEvent kp ixn of
+                  Left err -> fail err
+                  Right signed1 -> do
+                    case Kel.append kel0 signed1 of
+                      Left err -> fail ("interaction append: " <> err)
+                      Right kel1 -> do
+                        case Kel.replay kel1 of
+                          Left err -> fail ("replay failed: " <> err)
+                          Right ks ->
+                            KS.stateSequenceNumber ks `shouldEqual` 1
+
+  it "rejects event with wrong sequence number" do
+    kp <- liftEffect NaCl.generateKeyPair
+    case mkPrimitive Ed25519PubKey kp.publicKey of
+      Left err -> fail err
+      Right prim -> do
+        let
+          key = Cesr.encode prim
+          icp = mkIcp key
+        case signEvent kp icp of
+          Left err -> fail err
+          Right signed0 -> do
+            case Kel.append emptyKel signed0 of
+              Left err -> fail ("inception append: " <> err)
+              Right kel0 -> do
+                let
+                  badIxn = mkInteraction
+                    { prefix: eventPrefix icp
+                    , sequenceNumber: 5
+                    , priorDigest: eventDigest icp
+                    , anchors: []
+                    }
+                case signEvent kp badIxn of
+                  Left err -> fail err
+                  Right signed1 ->
+                    case Kel.append kel0 signed1 of
+                      Left _ -> pure unit
+                      Right _ -> fail "should have rejected wrong sequence"

--- a/client/test/Test/Main.purs
+++ b/client/test/Test/Main.purs
@@ -1,0 +1,24 @@
+module Test.Main where
+
+import Prelude
+
+import Effect (Effect)
+import Test.Spec.Reporter (consoleReporter)
+import Test.Spec.Runner.Node (runSpecAndExitProcess)
+import Test.Keri.Cesr.RoundtripSpec as CesrSpec
+import Test.Keri.Crypto.DigestSpec as DigestSpec
+import Test.Keri.Event.InceptionSpec as InceptionSpec
+import Test.Keri.KelSpec as KelSpec
+import Test.Domain.StateSpec as StateSpec
+import Test.Domain.ValidateSpec as ValidateSpec
+import Test.Protocol.MessageSpec as MessageSpec
+
+main :: Effect Unit
+main = runSpecAndExitProcess [ consoleReporter ] do
+  CesrSpec.spec
+  DigestSpec.spec
+  InceptionSpec.spec
+  KelSpec.spec
+  StateSpec.spec
+  ValidateSpec.spec
+  MessageSpec.spec

--- a/client/test/Test/Protocol/MessageSpec.purs
+++ b/client/test/Test/Protocol/MessageSpec.purs
@@ -1,0 +1,91 @@
+module Test.Protocol.MessageSpec where
+
+import Prelude
+
+import Data.Either (Either(..))
+import Effect.Class (liftEffect)
+import FFI.TweetNaCl as NaCl
+import Keri.Cesr.DerivationCode (DerivationCode(..))
+import Keri.Cesr.Encode as Cesr
+import Keri.Cesr.Primitive (mkPrimitive)
+import Keri.Event (Event(..), eventDigest, eventPrefix)
+import Keri.Event.Inception (mkInception)
+import Keri.KeyState (initialState) as KS
+import Domain.Event (DomainEvent(..))
+import Domain.Types (AID(..), MemberId(..), MemberName(..), PurchaseName(..))
+import Protocol.Message (extractSignedEvent, mkGroupMessage, verifyGroupMessage)
+import Test.Spec (Spec, describe, it)
+import Test.Spec.Assertions (shouldEqual, fail)
+
+spec :: Spec Unit
+spec = describe "Protocol.Message" do
+  it "creates and verifies a signed group message" do
+    kp <- liftEffect NaCl.generateKeyPair
+    case mkPrimitive Ed25519PubKey kp.publicKey of
+      Left err -> fail err
+      Right prim -> do
+        let
+          key = Cesr.encode prim
+          icp = mkInception
+            { keys: [ key ]
+            , signingThreshold: 1
+            , nextKeys: []
+            , nextThreshold: 0
+            , config: []
+            , anchors: []
+            }
+          prefix = eventPrefix icp
+          digest = eventDigest icp
+        case icp of
+          Inception d -> do
+            let ks = KS.initialState d
+            case
+              mkGroupMessage
+                { prefix
+                , sequenceNumber: 1
+                , priorDigest: digest
+                , secretKey: kp
+                , keyIndex: 0
+                }
+                (VoteRegisterMember (MemberName "Alice"))
+              of
+              Left err -> fail ("mkGroupMessage failed: " <> err)
+              Right msg ->
+                verifyGroupMessage ks msg `shouldEqual` true
+          _ -> fail "Expected Inception event"
+
+  it "extractSignedEvent returns correct signer" do
+    kp <- liftEffect NaCl.generateKeyPair
+    case mkPrimitive Ed25519PubKey kp.publicKey of
+      Left err -> fail err
+      Right prim -> do
+        let
+          key = Cesr.encode prim
+          icp = mkInception
+            { keys: [ key ]
+            , signingThreshold: 1
+            , nextKeys: []
+            , nextThreshold: 0
+            , config: []
+            , anchors: []
+            }
+          prefix = eventPrefix icp
+          digest = eventDigest icp
+
+        case
+          mkGroupMessage
+            { prefix
+            , sequenceNumber: 1
+            , priorDigest: digest
+            , secretKey: kp
+            , keyIndex: 0
+            }
+            (OpenPurchase (PurchaseName "Oranges"))
+          of
+          Left err -> fail ("mkGroupMessage failed: " <> err)
+          Right msg -> do
+            let signed = extractSignedEvent msg
+            signed.signer `shouldEqual` MemberId (AID prefix)
+            case signed.event of
+              OpenPurchase _ -> pure unit
+              _ -> fail "Expected OpenPurchase event"

--- a/justfile
+++ b/justfile
@@ -1,5 +1,7 @@
 set unstable := true
 
+nix := "nix develop --quiet -c bash -c"
+
 # List available recipes
 default:
     @just --list
@@ -8,47 +10,41 @@ default:
 
 # Build Haskell server
 build:
-    cabal build all -O0
+    {{ nix }} "cabal build all -O0"
 
 # Format all source files
 format:
     #!/usr/bin/env bash
     set -euo pipefail
     just format-client
-    hs_files=$(find . -name '*.hs' -not -path './dist-newstyle/*' -not -path './.direnv/*')
-    for i in {1..3}; do
-        fourmolu -i $hs_files
-    done
-    find . -name '*.cabal' -not -path './dist-newstyle/*' | xargs cabal-fmt -i
-    find . -name '*.nix' -not -path './dist-newstyle/*' | xargs nixfmt
-
-# Run Haskell linter
-lint:
-    #!/usr/bin/env bash
-    set -euo pipefail
-    just lint-client
+    nix develop --quiet -c bash -c '
+        hs_files=$(find . -name "*.hs" -not -path "./dist-newstyle/*" -not -path "./.direnv/*")
+        for i in {1..3}; do fourmolu -i $hs_files; done
+        find . -name "*.cabal" -not -path "./dist-newstyle/*" | xargs cabal-fmt -i
+        find . -name "*.nix" -not -path "./dist-newstyle/*" | xargs nixfmt
+    '
 
 # -- PureScript client --
 
 # Build PureScript client (warnings are errors)
 build-client:
-    cd client && spago build --quiet --strict
+    {{ nix }} "cd client && spago build --quiet --strict"
 
 # Bundle PureScript client for browser
 bundle-client:
-    cd client && npm ci --silent && spago bundle --quiet --strict
+    {{ nix }} "cd client && npm ci --silent && spago bundle --quiet --strict"
 
 # Format PureScript sources
 format-client:
-    cd client && purs-tidy format-in-place 'src/**/*.purs'
+    {{ nix }} "cd client && purs-tidy format-in-place 'src/**/*.purs' 'test/**/*.purs'"
 
 # Lint PureScript sources
 lint-client:
-    cd client && purs-tidy check 'src/**/*.purs'
+    {{ nix }} "cd client && purs-tidy check 'src/**/*.purs' 'test/**/*.purs'"
 
-# Run PureScript tests
+# Run PureScript tests (run npm ci first if node_modules missing)
 test-client:
-    cd client && spago test
+    {{ nix }} "cd client && spago test"
 
 # -- Combined --
 
@@ -59,6 +55,8 @@ ci:
     just build
     just lint-client
     just build-client
+    {{ nix }} "cd client && npm ci --silent"
+    just test-client
     just bundle-client
 
 # Run server serving client bundle
@@ -66,7 +64,7 @@ serve:
     #!/usr/bin/env bash
     set -euo pipefail
     just bundle-client
-    cabal run keri-coop-server -O0 -- --static-dir client/dist
+    {{ nix }} "cabal run keri-coop-server -O0 -- --static-dir client/dist"
 
 # Build docker image
 docker:


### PR DESCRIPTION
## Summary
- 43 tests covering CESR roundtrip, digest computation, inception events, KEL append/replay, domain state transitions, validation rules, and protocol message signing/verification
- Added `spec` and `spec-node` dependencies
- Added `Show` instances for `PurchasePhase`, `CommitmentStatus`, and `ValidationError` to support test assertions

## Test plan
- [x] `just test-client` passes (43/43)
- [x] `just ci` passes (strict build + bundle)