### PR TITLE
feat: add SAID verification on event ingestion

### DIFF
--- a/src/Keri/Crypto/SAID.purs
+++ b/src/Keri/Crypto/SAID.purs
@@ -1,0 +1,23 @@
+module Keri.Crypto.SAID
+  ( verifySaid
+  , replaceDigest
+  ) where
+
+import Prelude
+
+import Keri.Crypto.Digest (computeSaid, saidPlaceholder)
+import Keri.Event (Event(..), eventDigest)
+import Keri.Event.Serialize (serializeEvent)
+
+-- | Replace the digest field with the SAID placeholder.
+-- For inception events, both digest and prefix are replaced
+-- (because the prefix is derived from the SAID).
+replaceDigest :: Event -> Event
+replaceDigest (Inception d) = Inception (d { digest = saidPlaceholder, prefix = saidPlaceholder })
+replaceDigest (Rotation d) = Rotation (d { digest = saidPlaceholder })
+replaceDigest (Interaction d) = Interaction (d { digest = saidPlaceholder })
+replaceDigest (Receipt d) = Receipt (d { digest = saidPlaceholder })
+
+-- | Verify that the event's claimed SAID matches the recomputed one.
+verifySaid :: Event -> Boolean
+verifySaid evt = computeSaid (serializeEvent (replaceDigest evt)) == eventDigest evt

--- a/src/Keri/Kel/Append.purs
+++ b/src/Keri/Kel/Append.purs
@@ -6,6 +6,7 @@ import Prelude
 
 import Data.Array (snoc, null)
 import Data.Either (Either(..))
+import Keri.Crypto.SAID (verifySaid)
 import Keri.Event (Event(..), eventSequenceNumber)
 import Keri.Event.Serialize (serializeEvent)
 import Keri.Kel (Kel, SignedEvent)
@@ -15,7 +16,7 @@ import Keri.KeyState as KS
 import Keri.KeyState.Verify (verifySignatures)
 
 -- | Append a signed event to a KEL after verifying
--- signatures and chain integrity.
+-- SAID integrity, signatures, and chain integrity.
 append :: Kel -> SignedEvent -> Either String Kel
 append kel se
   | null kel = appendInception se
@@ -23,24 +24,28 @@ append kel se
 
 appendInception :: SignedEvent -> Either String Kel
 appendInception se = case se.event of
-  Inception d -> do
-    let
-      msgStr = serializeEvent se.event
-      ks = initialState d
-    if verifySignatures (KS.stateKeys ks) (KS.stateSigningThreshold ks) msgStr se.signatures then Right [ se ]
-    else Left "Inception signatures invalid"
+  Inception d ->
+    if not (verifySaid se.event) then Left "SAID verification failed"
+    else do
+      let
+        msgStr = serializeEvent se.event
+        ks = initialState d
+      if verifySignatures (KS.stateKeys ks) (KS.stateSigningThreshold ks) msgStr se.signatures then Right [ se ]
+      else Left "Inception signatures invalid"
   _ -> Left "First event must be inception"
 
 appendToExisting :: Kel -> SignedEvent -> Either String Kel
 appendToExisting kel se = do
-  ks <- replay kel
-  let msgStr = serializeEvent se.event
-  if not (verifySignatures (KS.stateKeys ks) (KS.stateSigningThreshold ks) msgStr se.signatures) then Left "Signatures invalid"
+  if not (verifySaid se.event) then Left "SAID verification failed"
   else do
-    let
-      expectedSn = KS.stateSequenceNumber ks + 1
-      actualSn = eventSequenceNumber se.event
-    if actualSn /= expectedSn then Left ("Expected sequence " <> show expectedSn <> ", got " <> show actualSn)
+    ks <- replay kel
+    let msgStr = serializeEvent se.event
+    if not (verifySignatures (KS.stateKeys ks) (KS.stateSigningThreshold ks) msgStr se.signatures) then Left "Signatures invalid"
     else do
-      _ <- applyEvent ks se.event
-      Right (snoc kel se)
+      let
+        expectedSn = KS.stateSequenceNumber ks + 1
+        actualSn = eventSequenceNumber se.event
+      if actualSn /= expectedSn then Left ("Expected sequence " <> show expectedSn <> ", got " <> show actualSn)
+      else do
+        _ <- applyEvent ks se.event
+        Right (snoc kel se)

--- a/test/Keri/Crypto/SAIDSpec.purs
+++ b/test/Keri/Crypto/SAIDSpec.purs
@@ -1,0 +1,89 @@
+module Test.Keri.Crypto.SAIDSpec where
+
+import Prelude
+
+import Data.Either (fromRight)
+import Effect.Class (liftEffect)
+import Keri.Crypto.Digest (saidPlaceholder)
+import Keri.Crypto.SAID (replaceDigest, verifySaid)
+import Keri.Event (Event(..), eventDigest, eventPrefix)
+import Keri.Event.Interaction (mkInteraction)
+import Keri.Event.Rotation (mkRotation)
+import Keri.KeyState.PreRotation (commitKey)
+import Test.Keri.TestHelper (mkTestInception, mkTestKeyPair)
+import Test.Spec (Spec, describe, it)
+import Test.Spec.Assertions (shouldEqual, shouldNotEqual)
+
+spec :: Spec Unit
+spec = describe "Crypto.SAID" do
+  describe "verifySaid" do
+    it "succeeds for mkInception" do
+      { event } ← mkTestInception
+      verifySaid event `shouldEqual` true
+
+    it "succeeds for mkInteraction" do
+      { event: icp } ← mkTestInception
+      let
+        ixn = mkInteraction
+          { prefix: eventPrefix icp
+          , sequenceNumber: 1
+          , priorDigest: eventDigest icp
+          , anchors: []
+          }
+      verifySaid ixn `shouldEqual` true
+
+    it "succeeds for mkRotation" do
+      { event: icp, nextKeyPair } ← mkTestInception
+      newNext ← liftEffect mkTestKeyPair
+      let
+        commitment = fromRight "" (commitKey newNext.cesrPubKey)
+        rot = mkRotation
+          { prefix: eventPrefix icp
+          , sequenceNumber: 1
+          , priorDigest: eventDigest icp
+          , keys: [ nextKeyPair.cesrPubKey ]
+          , signingThreshold: 1
+          , nextKeys: [ commitment ]
+          , nextThreshold: 1
+          , config: []
+          , anchors: []
+          }
+      verifySaid rot `shouldEqual` true
+
+    it "fails for tampered signingThreshold" do
+      { event } ← mkTestInception
+      case event of
+        Inception d →
+          verifySaid (Inception (d { signingThreshold = 99 })) `shouldEqual` false
+        _ → "inception" `shouldEqual` "not inception"
+
+    it "fails for wrong digest field" do
+      { event } ← mkTestInception
+      case event of
+        Inception d →
+          verifySaid (Inception (d { digest = "wrong" })) `shouldEqual` false
+        _ → "inception" `shouldEqual` "not inception"
+
+  describe "replaceDigest" do
+    it "replaces inception digest + prefix" do
+      { event } ← mkTestInception
+      case replaceDigest event of
+        Inception d → do
+          d.digest `shouldEqual` saidPlaceholder
+          d.prefix `shouldEqual` saidPlaceholder
+        _ → "inception" `shouldEqual` "not inception"
+
+    it "replaces interaction digest only" do
+      { event: icp } ← mkTestInception
+      let
+        ixn = mkInteraction
+          { prefix: eventPrefix icp
+          , sequenceNumber: 1
+          , priorDigest: eventDigest icp
+          , anchors: []
+          }
+      case replaceDigest ixn of
+        Interaction d → do
+          d.digest `shouldEqual` saidPlaceholder
+          d.prefix `shouldNotEqual` saidPlaceholder
+        _ → "interaction" `shouldEqual` "not interaction"

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -10,6 +10,7 @@ import Test.Keri.Cesr.DecodeSpec as DecodeSpec
 import Test.Keri.Crypto.Blake3Spec as Blake3Spec
 import Test.Keri.Crypto.DigestSpec as DigestSpec
 import Test.Keri.Crypto.Ed25519Spec as Ed25519Spec
+import Test.Keri.Crypto.SAIDSpec as SAIDSpec
 import Test.Keri.Event.InceptionSpec as InceptionSpec
 import Test.Keri.Event.RotationSpec as RotationSpec
 import Test.Keri.Event.InteractionSpec as InteractionSpec
@@ -29,6 +30,7 @@ main = runSpecAndExitProcess [ consoleReporter ] do
   Blake3Spec.spec
   DigestSpec.spec
   Ed25519Spec.spec
+  SAIDSpec.spec
   InceptionSpec.spec
   RotationSpec.spec
   InteractionSpec.spec


### PR DESCRIPTION
## Summary
- New `Keri.Crypto.SAID` module with `verifySaid` and `replaceDigest`
- SAID check added to `Keri.Kel.Append` before signature verification
- 8 new tests (7 SAID + 1 KEL tampered rejection)

## Test plan
- [ ] `nix develop --quiet -c just test` — 101 tests pass